### PR TITLE
Add comprehensive unit tests

### DIFF
--- a/Synthea.Cli.Tests/JarManagerTests.cs
+++ b/Synthea.Cli.Tests/JarManagerTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Synthea.Cli;
+using Xunit;
+
+namespace Synthea.Cli.Tests;
+
+public class JarManagerTests : IDisposable
+{
+    private readonly string _tempDir;
+    public JarManagerTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_tempDir);
+        JarManager.CacheRootOverride = _tempDir;
+        Environment.SetEnvironmentVariable("TMPDIR", _tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, true); } catch { }
+    }
+
+    private static HttpClient CreateClient(Dictionary<string,string> texts, Dictionary<string,byte[]> binaries)
+    {
+        return new HttpClient(new StubHandler(texts,binaries));
+    }
+
+    [Fact]
+    public async Task ReturnsCachedFileWhenPresent()
+    {
+        var cache = Path.Combine(_tempDir, "synthea-cli");
+        Directory.CreateDirectory(cache);
+        var existing = Path.Combine(cache, "cached-with-dependencies.jar");
+        await File.WriteAllTextAsync(existing, "dummy");
+        JarManager.Http = CreateClient(new(), new());
+
+        var fi = await JarManager.EnsureJarAsync();
+        Assert.Equal(existing, fi.FullName);
+    }
+
+    [Fact]
+    public async Task DownloadsJarWhenMissing()
+    {
+        var releaseJson = "{\"assets\":[{\"name\":\"synthea-with-dependencies.jar\",\"browser_download_url\":\"http://host/jar\"}]}";
+        var jarBytes = new byte[]{1,2,3};
+        var texts = new Dictionary<string,string> { {"https://api.github.com/repos/synthetichealth/synthea/releases/latest", releaseJson} };
+        var bins = new Dictionary<string,byte[]> { {"http://host/jar", jarBytes} };
+        JarManager.Http = CreateClient(texts,bins);
+
+        var fi = await JarManager.EnsureJarAsync();
+        Assert.True(File.Exists(fi.FullName));
+        Assert.Equal(jarBytes, File.ReadAllBytes(fi.FullName));
+    }
+
+    [Fact]
+    public async Task ThrowsWhenChecksumMismatch()
+    {
+        var releaseJson = "{\"assets\":[{\"name\":\"synthea-with-dependencies.jar\",\"browser_download_url\":\"http://host/jar\"},{\"name\":\"synthea.jar.sha256\",\"browser_download_url\":\"http://host/jar.sha\"}]}";
+        var jarBytes = new byte[]{4,5,6};
+        var texts = new Dictionary<string,string>
+        {
+            {"https://api.github.com/repos/synthetichealth/synthea/releases/latest", releaseJson},
+            {"http://host/jar.sha", "deadbeef"}
+        };
+        var bins = new Dictionary<string,byte[]> { {"http://host/jar", jarBytes} };
+        JarManager.Http = CreateClient(texts,bins);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => JarManager.EnsureJarAsync());
+    }
+
+    private class StubHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<string,string> _texts;
+        private readonly Dictionary<string,byte[]> _bins;
+        public StubHandler(Dictionary<string,string> texts, Dictionary<string,byte[]> bins)
+        {
+            _texts = texts;
+            _bins = bins;
+        }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri!.ToString();
+            if (_texts.TryGetValue(url, out var text))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK){ Content = new StringContent(text) });
+            }
+            if (_bins.TryGetValue(url, out var data))
+            {
+                var resp = new HttpResponseMessage(HttpStatusCode.OK){ Content = new ByteArrayContent(data) };
+                resp.Content.Headers.ContentLength = data.Length;
+                return Task.FromResult(resp);
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound){RequestMessage = request});
+        }
+    }
+}

--- a/Synthea.Cli.Tests/ProgramHandlerTests.cs
+++ b/Synthea.Cli.Tests/ProgramHandlerTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.IO;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Synthea.Cli;
+using Xunit;
+
+namespace Synthea.Cli.Tests;
+
+public class ProgramHandlerTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly FileInfo _jar;
+    private readonly CapturingRunner _runner = new();
+
+    public ProgramHandlerTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_tempDir);
+        _jar = new FileInfo(Path.Combine(_tempDir, "synthea.jar"));
+        File.WriteAllText(_jar.FullName, "jar");
+        Program.Runner = _runner;
+        Program.EnsureJarAsyncFunc = (_,_,_) => Task.FromResult(_jar);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, true); } catch { }
+        Program.Runner = new DefaultProcessRunner();
+        Program.EnsureJarAsyncFunc = JarManager.EnsureJarAsync;
+    }
+
+    [Fact]
+    public async Task BuildsProcessStartInfoWithStateAndCity()
+    {
+        var outDir = Path.Combine(_tempDir, "out1");
+        var code = await Program.Main(new[] { "run", "--output", outDir, "--state", "OH", "--city", "Cleveland" });
+        Assert.Equal(0, code);
+
+        var psi = _runner.StartInfo!;
+        Assert.Equal("java", psi.FileName);
+        Assert.Equal(outDir, psi.WorkingDirectory);
+        Assert.Equal(new[] { "-jar", _jar.FullName, "OH", "Cleveland" }, psi.ArgumentList);
+        Assert.True(Directory.Exists(outDir));
+    }
+
+    [Fact]
+    public async Task UsesCustomJavaPath()
+    {
+        var outDir = Path.Combine(_tempDir, "out2");
+        var code = await Program.Main(new[] { "run", "--output", outDir, "--java-path", "/usr/bin/custom" });
+        Assert.Equal(0, code);
+        Assert.Equal("/usr/bin/custom", _runner.StartInfo!.FileName);
+    }
+
+    private class CapturingRunner : IProcessRunner
+    {
+        public ProcessStartInfo? StartInfo;
+        public IProcess Start(ProcessStartInfo psi)
+        {
+            StartInfo = psi;
+            return new StubProcess();
+        }
+
+        private class StubProcess : IProcess
+        {
+            public StreamReader StandardOutput { get; } = new StreamReader(new MemoryStream());
+            public StreamReader StandardError { get; } = new StreamReader(new MemoryStream());
+            public int ExitCode => 0;
+            public Task WaitForExitAsync() => Task.CompletedTask;
+            public void Dispose() { }
+        }
+    }
+}

--- a/Synthea.Cli/Synthea.Cli.csproj
+++ b/Synthea.Cli/Synthea.Cli.csproj
@@ -12,5 +12,9 @@
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Synthea.Cli.Tests" />
+  </ItemGroup>
+
 
 </Project>


### PR DESCRIPTION
## Summary
- add injection points for `HttpClient`, cache path, and process running
- expose internals to test project
- implement tests for `JarManager` download logic
- implement tests for `Program` run-command handler

## Testing
- `dotnet test --collect:"XPlat Code Coverage" -nologo`