### PR TITLE
Fix dotnet pack failure

### DIFF
--- a/Synthea.Cli/Synthea.Cli.csproj
+++ b/Synthea.Cli/Synthea.Cli.csproj
@@ -16,7 +16,6 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/Kmanley1/synthea-cli</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- remove `GeneratePackageOnBuild` from `Synthea.Cli.csproj`

## Testing
- `dotnet test Synthea.Cli.Tests/Synthea.Cli.Tests.csproj -c Release`
- `dotnet pack Synthea.Cli/Synthea.Cli.csproj -c Release /p:ContinuousIntegrationBuild=true /p:PackageVersion=0.1.0 -v minimal`