### PR TITLE
Fix dotnet pack workflow

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -17,7 +17,12 @@ jobs:
         with:
           dotnet-version: '8.0.x'
       - name: Set version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+        run: |
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+          else
+            echo "VERSION=0.0.0-${GITHUB_SHA::7}" >> $GITHUB_ENV
+          fi
       - name: Pack
         run: dotnet pack Synthea.Cli/Synthea.Cli.csproj -c Release /p:ContinuousIntegrationBuild=true /p:PackageVersion=${{ env.VERSION }}
       - name: Push

--- a/Synthea.Cli/Synthea.Cli.csproj
+++ b/Synthea.Cli/Synthea.Cli.csproj
@@ -16,7 +16,6 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/Kmanley1/synthea-cli</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- set a valid pre-release package version for branch builds

## Testing
- `dotnet test Synthea.Cli.Tests/Synthea.Cli.Tests.csproj -c Release`
- `dotnet pack Synthea.Cli/Synthea.Cli.csproj -c Release /p:ContinuousIntegrationBuild=true /p:PackageVersion=0.0.0-test`
