### PR TITLE
Improve setup script with dependency checks

### DIFF
--- a/Synthea.Cli/Synthea.Cli.csproj
+++ b/Synthea.Cli/Synthea.Cli.csproj
@@ -16,7 +16,6 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/Kmanley1/synthea-cli</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/run/setup.sh
+++ b/run/setup.sh
@@ -3,12 +3,20 @@
 
 set -euo pipefail
 
-# 1) Install runtimes (approx 150 MB)
-sudo apt-get update -qq
-sudo apt-get install -y --no-install-recommends \
-    openjdk-17-jre-headless \
-    dotnet-sdk-8.0 \
- && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
+# 1) Ensure Java 17+ and .NET 8 are present. Skip apt if already installed.
+packages=()
+if ! command -v java >/dev/null; then
+    packages+=(openjdk-17-jre-headless)
+fi
+if ! command -v dotnet >/dev/null; then
+    packages+=(dotnet-sdk-8.0)
+fi
+if [ ${#packages[@]} -ne 0 ]; then
+    sudo apt-get update -qq
+    sudo apt-get install -y --no-install-recommends "${packages[@]}"
+    sudo apt-get clean
+    sudo rm -rf /var/lib/apt/lists/*
+fi
 
 # 2) Restore & publish the CLI
 dotnet restore --nologo

--- a/setup.sh
+++ b/setup.sh
@@ -3,12 +3,20 @@
 
 set -euo pipefail
 
-# 1) Install runtimes (approx 150 MB)
-sudo apt-get update -qq
-sudo apt-get install -y --no-install-recommends \
-    openjdk-17-jre-headless \
-    dotnet-sdk-8.0 \
- && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
+# 1) Ensure Java 17+ and .NET 8 are present. Skip apt if already installed.
+packages=()
+if ! command -v java >/dev/null; then
+    packages+=(openjdk-17-jre-headless)
+fi
+if ! command -v dotnet >/dev/null; then
+    packages+=(dotnet-sdk-8.0)
+fi
+if [ ${#packages[@]} -ne 0 ]; then
+    sudo apt-get update -qq
+    sudo apt-get install -y --no-install-recommends "${packages[@]}"
+    sudo apt-get clean
+    sudo rm -rf /var/lib/apt/lists/*
+fi
 
 # 2) Restore & publish the CLI
 dotnet restore --nologo


### PR DESCRIPTION
## Summary
- check for Java & dotnet before installing packages in setup script
- do the same in `run/setup.sh`

## Testing
- `dotnet test Synthea.Cli.Tests/Synthea.Cli.Tests.csproj -c Release`
- `dotnet pack Synthea.Cli/Synthea.Cli.csproj -c Release /p:ContinuousIntegrationBuild=true /p:PackageVersion=0.1.0 -v minimal`
