### PR TITLE
Add seed option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The tool downloads the latest Synthea JAR on first use, caches it locally, and g
 |---------|---------|
 | **Zero-install JAR** | Automatically fetches the newest `synthea-with-dependencies.jar` from GitHub releases and verifies its SHA-256 checksum. |
 | **Configurable cache** | Stores the JAR under `%LOCALAPPDATA%\synthea-cli` / `$XDG_CACHE_HOME/synthea-cli`; refresh anytime with `--refresh`. |
-| **Friendly flags** | `--state OH`, `--city "Columbus"`, `--output ./data` map to Synthea’s positional arguments and working directory. |
+| **Friendly flags** | `--state OH`, `--city "Columbus"`, `--output ./data`, `--seed 42` map to Synthea’s positional arguments and working directory. |
 | **Portable** | Runs on Windows, macOS, Linux, containers—wherever .NET 8 + Java 17+ are available. |
 | **Docker image** | Multi-stage Dockerfile builds a slim runtime with OpenJDK 17 and publishes the tool. |
 | **Unit-tested** | ≥ 90 % line coverage via xUnit and Coverlet; network & process calls are fully mocked. |
@@ -58,8 +58,8 @@ dotnet tool install --global synthea-cli --version 0.1.0
 ### Run
 
 ```bash
-# Generate 10 synthetic patients from Ohio into ./output
-synthea run --output ./output --population 10 --state OH
+# Generate 10 synthetic patients from Ohio into ./output using a fixed seed
+synthea run --output ./output --population 10 --state OH --seed 12345
 
 # Same, but force-refresh the cached JAR
 synthea --refresh run -o ./output --population 10 --state TX --city Austin

--- a/Synthea.Cli.Tests/ProgramHandlerTests.cs
+++ b/Synthea.Cli.Tests/ProgramHandlerTests.cs
@@ -70,6 +70,39 @@ public class ProgramHandlerTests : IDisposable
         Assert.NotEqual(0, code);
     }
 
+    [Fact]
+    public async Task ForwardsSeedOption()
+    {
+        var outDir = Path.Combine(_tempDir, "out5");
+        var code = await Program.Main(new[] { "run", "--output", outDir, "-s", "123" });
+        Assert.Equal(0, code);
+        Assert.Equal(new[] { "-jar", _jar.FullName, "-s", "123" }, _runner.StartInfo!.ArgumentList);
+    }
+
+    [Fact]
+    public async Task InvalidSeedReturnsError()
+    {
+        var outDir = Path.Combine(_tempDir, "out6");
+        var code = await Program.Main(new[] { "run", "--output", outDir, "-s", "oops" });
+        Assert.NotEqual(0, code);
+    }
+
+    [Fact]
+    public async Task SameSeedProducesSameArguments()
+    {
+        var outDir1 = Path.Combine(_tempDir, "out7a");
+        var code1 = await Program.Main(new[] { "run", "--output", outDir1, "-s", "77" });
+        Assert.Equal(0, code1);
+        var args1 = _runner.StartInfo!.ArgumentList.ToArray();
+
+        var outDir2 = Path.Combine(_tempDir, "out7b");
+        var code2 = await Program.Main(new[] { "run", "--output", outDir2, "-s", "77" });
+        Assert.Equal(0, code2);
+        var args2 = _runner.StartInfo!.ArgumentList.ToArray();
+
+        Assert.Equal(args1, args2);
+    }
+
     private class CapturingRunner : IProcessRunner
     {
         public ProcessStartInfo? StartInfo;

--- a/Synthea.Cli/Program.cs
+++ b/Synthea.Cli/Program.cs
@@ -83,6 +83,16 @@ internal static class Program
                 r.ErrorMessage = "Population must be a positive integer.";
         });
 
+        var seedOpt = new Option<int?>(
+            aliases: new[] { "--seed", "-s" },
+            description: "Random seed for deterministic output");
+        seedOpt.AddValidator(r =>
+        {
+            if (r.Tokens.Count == 0) return;
+            if (!int.TryParse(r.Tokens[0].Value, out _))
+                r.ErrorMessage = "Random seed must be an integer.";
+        });
+
         // capture *any* additional Synthea flags
         var passthru = new Argument<string[]>("args")
         {
@@ -94,6 +104,7 @@ internal static class Program
         runCmd.AddOption(stateOpt);
         runCmd.AddOption(cityOpt);
         runCmd.AddOption(popOpt);
+        runCmd.AddOption(seedOpt);
         runCmd.AddArgument(passthru);
         // Forward any unrecognized options directly to Synthea
         runCmd.TreatUnmatchedTokensAsErrors = false;
@@ -107,6 +118,7 @@ internal static class Program
             var state     = ctx.ParseResult.GetValueForOption(stateOpt);
             var city      = ctx.ParseResult.GetValueForOption(cityOpt);
             var pop       = ctx.ParseResult.GetValueForOption(popOpt);
+            var seed      = ctx.ParseResult.GetValueForOption(seedOpt);
             var rest      = ctx.ParseResult.GetValueForArgument(passthru);
 
             Directory.CreateDirectory(outDir.FullName);
@@ -126,6 +138,11 @@ internal static class Program
             {
                 argList.Add("-p");
                 argList.Add(pop.Value.ToString());
+            }
+            if (seed.HasValue)
+            {
+                argList.Add("-s");
+                argList.Add(seed.Value.ToString());
             }
             argList.AddRange(rest);
             if (!string.IsNullOrWhiteSpace(state)) argList.Add(state);


### PR DESCRIPTION
## Summary
- add --seed/-s option to Program.cs
- validate seed argument and pass it to Synthea
- test seed parsing and determinism
- document random seed usage

## Testing
- `dotnet test --verbosity minimal`