### PR TITLE
Add snapshot options and format selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The tool downloads the latest Synthea JAR on first use, caches it locally, and g
 |---------|---------|
 | **Zero-install JAR** | Automatically fetches the newest `synthea-with-dependencies.jar` from GitHub releases and verifies its SHA-256 checksum. |
 | **Configurable cache** | Stores the JAR under `%LOCALAPPDATA%\synthea-cli` / `$XDG_CACHE_HOME/synthea-cli`; refresh anytime with `--refresh`. |
-| **Friendly flags** | `--state OH`, `--city "Columbus"`, `--output ./data`, `--seed 42` map to Synthea’s positional arguments and working directory. |
+| **Friendly flags** | `--state OH`, `--city "Columbus"`, `--output ./data`, `--seed 42`, `--initial-snapshot snap.json`, `--format FHIR` map directly to Synthea flags. |
 | **Portable** | Runs on Windows, macOS, Linux, containers—wherever .NET 8 + Java 17+ are available. |
 | **Docker image** | Multi-stage Dockerfile builds a slim runtime with OpenJDK 17 and publishes the tool. |
 | **Unit-tested** | ≥ 90 % line coverage via xUnit and Coverlet; network & process calls are fully mocked. |
@@ -63,6 +63,9 @@ synthea run --output ./output --population 10 --state OH --seed 12345
 
 # Same, but force-refresh the cached JAR
 synthea --refresh run -o ./output --population 10 --state TX --city Austin
+
+# Advance 30 days from an initial snapshot and limit to CSV output only
+synthea run -o ./output --initial-snapshot snap.json --days-forward 30 --format CSV
 ```
 
 > **Short alias:** `syn` works everywhere `synthea` does.


### PR DESCRIPTION
## Summary
- implement initial/updated snapshot options and days-forward
- add output format selection
- document new options in README
- test snapshot, format, and invalid inputs

## Testing
- `dotnet build`
- `dotnet test --no-build`