### PR TITLE
Fix duplicate NuGet push

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -24,6 +24,8 @@ jobs:
 
           fi
       - name: Pack
-        run: dotnet pack Synthea.Cli/Synthea.Cli.csproj -c Release /p:ContinuousIntegrationBuild=true /p:PackageVersion=${{ env.VERSION }}
+        run: |
+          dotnet pack Synthea.Cli/Synthea.Cli.csproj -c Release -o artifacts \
+            /p:ContinuousIntegrationBuild=true /p:PackageVersion=${{ env.VERSION }}
       - name: Push
-        run: dotnet nuget push **/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
## Summary
- push only the freshly built nupkg in GitHub Actions

## Testing
- `bash setup.sh`
- `dotnet test Synthea.Cli.sln`