### PR TITLE
Add integration test project scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup
+        run: ./setup.sh
+      - name: Run Unit Tests
+        run: dotnet test --filter Category!=Integration
+      - name: Run Integration Tests
+        run: dotnet test --filter Category=Integration

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/Synthea.Cli.sln
+++ b/Synthea.Cli.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Synthea.Cli", "Synthea.Cli\Synthea.Cli.csproj", "{CCE15CD9-717A-4E46-A3BB-ADCF87F66042}"
 EndProject
-kProject("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{B8D5A6E7-3A02-4B1C-9C2D-EF1234567890}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{B8D5A6E7-3A02-4B1C-9C2D-EF1234567890}"
 	ProjectSection(SolutionItems) = preProject
 		docs\Architecture.md = docs\Architecture.md
 	EndProjectSection
@@ -27,6 +27,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Synthea.Cli.IntegrationTests", "tests\Synthea.Cli.IntegrationTests\Synthea.Cli.IntegrationTests.csproj", "{DF9A293C-B891-4CB5-8DB2-D9A32F47FBC5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -62,6 +64,18 @@ Global
 		{8196CA03-713A-42E9-9972-DC99C55970DD}.Release|x64.Build.0 = Release|Any CPU
 		{8196CA03-713A-42E9-9972-DC99C55970DD}.Release|x86.ActiveCfg = Release|Any CPU
 		{8196CA03-713A-42E9-9972-DC99C55970DD}.Release|x86.Build.0 = Release|Any CPU
+		{DF9A293C-B891-4CB5-8DB2-D9A32F47FBC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF9A293C-B891-4CB5-8DB2-D9A32F47FBC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DF9A293C-B891-4CB5-8DB2-D9A32F47FBC5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DF9A293C-B891-4CB5-8DB2-D9A32F47FBC5}.Debug|x64.Build.0 = Debug|Any CPU
+		{DF9A293C-B891-4CB5-8DB2-D9A32F47FBC5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DF9A293C-B891-4CB5-8DB2-D9A32F47FBC5}.Debug|x86.Build.0 = Debug|Any CPU
+		{DF9A293C-B891-4CB5-8DB2-D9A32F47FBC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DF9A293C-B891-4CB5-8DB2-D9A32F47FBC5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DF9A293C-B891-4CB5-8DB2-D9A32F47FBC5}.Release|x64.ActiveCfg = Release|Any CPU
+		{DF9A293C-B891-4CB5-8DB2-D9A32F47FBC5}.Release|x64.Build.0 = Release|Any CPU
+		{DF9A293C-B891-4CB5-8DB2-D9A32F47FBC5}.Release|x86.ActiveCfg = Release|Any CPU
+		{DF9A293C-B891-4CB5-8DB2-D9A32F47FBC5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/run/setup.sh
+++ b/run/setup.sh
@@ -11,6 +11,10 @@ fi
 if ! command -v dotnet >/dev/null; then
     packages+=(dotnet-sdk-8.0)
 fi
+# Some tests rely on the standard zip utilities
+if ! command -v zip >/dev/null; then
+    packages+=(zip unzip)
+fi
 if [ ${#packages[@]} -ne 0 ]; then
     sudo apt-get update -qq
     sudo apt-get install -y --no-install-recommends "${packages[@]}"

--- a/setup.sh
+++ b/setup.sh
@@ -11,6 +11,10 @@ fi
 if ! command -v dotnet >/dev/null; then
     packages+=(dotnet-sdk-8.0)
 fi
+# Some tests rely on the standard zip utilities
+if ! command -v zip >/dev/null; then
+    packages+=(zip unzip)
+fi
 if [ ${#packages[@]} -ne 0 ]; then
     sudo apt-get update -qq
     sudo apt-get install -y --no-install-recommends "${packages[@]}"

--- a/tests/Synthea.Cli.IntegrationTests/GlobalUsings.cs
+++ b/tests/Synthea.Cli.IntegrationTests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Synthea.Cli.IntegrationTests/ScaffoldingSmokeTest.cs
+++ b/tests/Synthea.Cli.IntegrationTests/ScaffoldingSmokeTest.cs
@@ -1,0 +1,10 @@
+using Xunit;
+
+namespace Synthea.Cli.IntegrationTests;
+
+[Trait("Category", "Integration")]
+public class ScaffoldingSmokeTest
+{
+    [Fact]
+    public void Project_Wires_Up() => Assert.True(true);
+}

--- a/tests/Synthea.Cli.IntegrationTests/Synthea.Cli.IntegrationTests.csproj
+++ b/tests/Synthea.Cli.IntegrationTests/Synthea.Cli.IntegrationTests.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <RootNamespace>Synthea.Cli.IntegrationTests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="**/*.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Synthea.Cli\Synthea.Cli.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- scaffold integration test project using xUnit
- run integration tests in CI after unit tests
- share build props across projects
- install zip utilities in setup script

## Testing
- `dotnet test --filter Category!=Integration` *(fails: Failed to restore packages)*
- `dotnet test --filter Category=Integration` *(fails: Failed to restore packages)*
- `bash setup.sh` *(fails: Failed to restore packages)*
