### PR TITLE
Update automation to always run context tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The tool downloads the latest Synthea JAR on first use, caches it locally, and g
     - [Docker](#docker)
     - [`setup.sh` for CI / Codex](#setupsh-for-ci--codex)
       - [GitHub Actions example](#github-actions-example)
+    - [Context Tasks](#context-tasks)
   - [Project Layout](#project-layout)
   - [Contributing](#contributing)
   - [License \& Credits](#license--credits)
@@ -114,12 +115,19 @@ docker run --rm -v "$PWD/out":/data synthea-cli            -- --state CA --popul
 
 #### GitHub Actions example
 
+
 ```yaml
 steps:
   - uses: actions/checkout@v4
   - run: ./setup.sh
   - run: dotnet /workspace/synthea-cli/bin/Synthea.Cli.dll -- --help
 ```
+
+### Context Tasks
+
+Task automation uses a `tasks/context` folder for reusable setup snippets. These
+files execute before every task run and stay in place. Only non-context tasks are
+moved to `tasks/implemented` after successful completion.
 
 ---
 

--- a/Synthea.Cli/CodexTaskProcessor.cs
+++ b/Synthea.Cli/CodexTaskProcessor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 
 namespace Synthea.Cli;
 
@@ -27,7 +28,27 @@ public static class CodexTaskProcessor
         Directory.CreateDirectory(sourceDir);
         Directory.CreateDirectory(targetDir);
 
-        foreach (var file in Directory.EnumerateFiles(sourceDir, "*.md"))
+        var contextDir = Path.Combine(sourceDir, "context");
+        if (!Directory.Exists(contextDir))
+        {
+            throw new DirectoryNotFoundException($"Context directory not found: {contextDir}");
+        }
+
+        foreach (var file in Directory.EnumerateFiles(contextDir, "*.md").OrderBy(f => f))
+        {
+            var name = Path.GetFileName(file);
+            try
+            {
+                Console.WriteLine($"Processing context task: {name}");
+                implementer.ImplementTask(file);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Error processing {name}: {ex.Message}");
+            }
+        }
+
+        foreach (var file in Directory.EnumerateFiles(sourceDir, "*.md", SearchOption.TopDirectoryOnly).OrderBy(f => f))
         {
             var name = Path.GetFileName(file);
             try


### PR DESCRIPTION
## Summary
- update CodexTaskProcessor to execute tasks in `tasks/context` before normal tasks and skip moving them
- ensure missing context dir throws clear exception
- test that context tasks run each time and aren't moved
- document context task behavior in README

## Testing
- `dotnet test`