### PR TITLE
Update automation path for tasks/context

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,11 @@ steps:
 
 ### Context Tasks
 
-Task automation uses a `tasks/context` folder for reusable setup snippets. These
-files execute before every task run and stay in place. Only non-context tasks are
-moved to `tasks/implemented` after successful completion.
+Task automation uses a `tasks/context` folder for reusable setup snippets.
+Pre-task files in `tasks/context/pre/` run before each normal task, while
+post-task files in `tasks/context/post/` run afterward. These context files stay
+in place and are never moved. Only non-context tasks are moved to
+`tasks/implemented` after successful completion.
 
 ---
 

--- a/Synthea.Cli/CodexTaskProcessor.cs
+++ b/Synthea.Cli/CodexTaskProcessor.cs
@@ -34,33 +34,38 @@ public static class CodexTaskProcessor
             throw new DirectoryNotFoundException($"Context directory not found: {contextDir}");
         }
 
-        foreach (var file in Directory.EnumerateFiles(contextDir, "*.md").OrderBy(f => f))
-        {
-            var name = Path.GetFileName(file);
-            try
-            {
-                Console.WriteLine($"Processing context task: {name}");
-                implementer.ImplementTask(file);
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine($"Error processing {name}: {ex.Message}");
-            }
-        }
+        var preDir = Path.Combine(contextDir, "pre");
+        var postDir = Path.Combine(contextDir, "post");
 
         foreach (var file in Directory.EnumerateFiles(sourceDir, "*.md", SearchOption.TopDirectoryOnly).OrderBy(f => f))
         {
             var name = Path.GetFileName(file);
+
+            var preFiles = Directory.Exists(preDir)
+                ? Directory.EnumerateFiles(preDir, "*.md").OrderBy(f => f)
+                : Enumerable.Empty<string>();
+            foreach (var pre in preFiles)
+            {
+                var pn = Path.GetFileName(pre);
+                try
+                {
+                    Console.WriteLine($"Processing pre-task: {pn}");
+                    implementer.ImplementTask(pre);
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Error processing {pn}: {ex.Message}");
+                }
+            }
+
             try
             {
                 Console.WriteLine($"Processing task: {name}");
                 if (implementer.IsTaskCompleted(file))
                 {
                     Console.WriteLine($"Task already completed: {name}");
-                    continue;
                 }
-                var success = implementer.ImplementTask(file);
-                if (success)
+                else if (implementer.ImplementTask(file))
                 {
                     var dest = Path.Combine(targetDir, name);
                     File.Move(file, dest, overwrite: true);
@@ -74,6 +79,25 @@ public static class CodexTaskProcessor
             catch (Exception ex)
             {
                 Console.Error.WriteLine($"Error processing {name}: {ex.Message}");
+            }
+            finally
+            {
+                var postFiles = Directory.Exists(postDir)
+                    ? Directory.EnumerateFiles(postDir, "*.md").OrderBy(f => f)
+                    : Enumerable.Empty<string>();
+                foreach (var post in postFiles)
+                {
+                    var pn = Path.GetFileName(post);
+                    try
+                    {
+                        Console.WriteLine($"Processing post-task: {pn}");
+                        implementer.ImplementTask(post);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine($"Error processing {pn}: {ex.Message}");
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- rework CodexTaskProcessor to look for `tasks/context` and handle `pre`/`post`
- test order of pre/post task execution and ensure context files stay put
- document new context task layout

## Testing
- `dotnet test tests/Synthea.Cli.UnitTests/Synthea.Cli.UnitTests.csproj -v minimal`
- `dotnet test tests/Synthea.Cli.IntegrationTests/Synthea.Cli.IntegrationTests.csproj -v minimal`
