### PR TITLE
chore(automation): enforce pre/post context task execution order

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The tool downloads the latest Synthea JAR on first use, caches it locally, and g
     - [Docker](#docker)
     - [`setup.sh` for CI / Codex](#setupsh-for-ci--codex)
       - [GitHub Actions example](#github-actions-example)
-    - [Context Tasks](#context-tasks)
+    - [Pre/Post Context Tasks](#prepost-context-tasks)
   - [Project Layout](#project-layout)
   - [Contributing](#contributing)
   - [License \& Credits](#license--credits)
@@ -123,13 +123,15 @@ steps:
   - run: dotnet /workspace/synthea-cli/bin/Synthea.Cli.dll -- --help
 ```
 
-### Context Tasks
+### Pre/Post Context Tasks
 
-Task automation uses a `tasks/context` folder for reusable setup snippets.
-Pre-task files in `tasks/context/pre/` run before each normal task, while
-post-task files in `tasks/context/post/` run afterward. These context files stay
-in place and are never moved. Only non-context tasks are moved to
-`tasks/implemented` after successful completion.
+Task automation uses a `tasks/context` folder for reusable setup snippets. Pre-task files
+in `tasks/context/pre/` run before each normal task, while post-task files in
+`tasks/context/post/` run afterward. These context files stay in place and are
+never moved. Only non-context tasks are moved to `tasks/implemented` after
+successful completion.
+
+See [docs/automation.md](docs/automation.md) for more details.
 
 ---
 

--- a/Synthea.Cli/CodexTaskProcessor.cs
+++ b/Synthea.Cli/CodexTaskProcessor.cs
@@ -37,6 +37,16 @@ public static class CodexTaskProcessor
         var preDir = Path.Combine(contextDir, "pre");
         var postDir = Path.Combine(contextDir, "post");
 
+        if (!Directory.Exists(preDir))
+        {
+            throw new DirectoryNotFoundException($"Pre-task directory not found: {preDir}");
+        }
+
+        if (!Directory.Exists(postDir))
+        {
+            throw new DirectoryNotFoundException($"Post-task directory not found: {postDir}");
+        }
+
         foreach (var file in Directory.EnumerateFiles(sourceDir, "*.md", SearchOption.TopDirectoryOnly).OrderBy(f => f))
         {
             var name = Path.GetFileName(file);

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -1,0 +1,15 @@
+# Automation Overview
+
+## Pre/Post Context Tasks
+
+The Codex automation processes tasks under `docs/tasks`. For each normal task file it:
+
+1. Runs all pre-task markdown files from `tasks/context/pre/` in sorted order.
+2. Executes the normal task file.
+3. Runs all post-task markdown files from `tasks/context/post/` in sorted order.
+
+Pre- and post-task directories must exist. If either is missing, the automation fails with a clear `DirectoryNotFoundException` message.
+
+Files anywhere under `tasks/context` are never moved to `tasks/implemented`.
+
+Use `CodexTaskProcessor.ProcessTasks` to run the automation. Pass `--dry-run` to print the execution order without performing moves.

--- a/tests/Synthea.Cli.UnitTests/CodexTaskProcessorTests.cs
+++ b/tests/Synthea.Cli.UnitTests/CodexTaskProcessorTests.cs
@@ -93,6 +93,24 @@ public class CodexTaskProcessorTests : IDisposable
         Assert.False(File.Exists(Path.Combine(_dest, "b.md")));
     }
 
+    [Fact]
+    public void ThrowsIfPreDirMissing()
+    {
+        Directory.Delete(_preDir, true);
+        var ex = Assert.Throws<DirectoryNotFoundException>(() =>
+            CodexTaskProcessor.ProcessTasks(_src, _dest, new StubImplementer(true)));
+        Assert.Contains("Pre-task directory", ex.Message);
+    }
+
+    [Fact]
+    public void ThrowsIfPostDirMissing()
+    {
+        Directory.Delete(_postDir, true);
+        var ex = Assert.Throws<DirectoryNotFoundException>(() =>
+            CodexTaskProcessor.ProcessTasks(_src, _dest, new StubImplementer(true)));
+        Assert.Contains("Post-task directory", ex.Message);
+    }
+
     private class StubImplementer : ITaskImplementer
     {
         private readonly bool _success;


### PR DESCRIPTION
## Summary
- enforce pre/post context directories exist and run order
- update README with new Pre/Post Context Tasks section
- document automation details in docs/automation.md
- test failures when pre or post directories are missing

## Testing
- `dotnet test tests/Synthea.Cli.UnitTests/Synthea.Cli.UnitTests.csproj --no-build -v minimal`
- `dotnet test tests/Synthea.Cli.IntegrationTests/Synthea.Cli.IntegrationTests.csproj --no-build -v minimal`