### PR TITLE
fix: automation moves tasks to implemented

### DIFF
--- a/Synthea.Cli/CodexTaskProcessor.cs
+++ b/Synthea.Cli/CodexTaskProcessor.cs
@@ -30,23 +30,24 @@ public static class CodexTaskProcessor
         Directory.CreateDirectory(targetDir);
 
         var contextDir = Path.Combine(sourceDir, "context");
-        if (!Directory.Exists(contextDir))
-        {
-            throw new DirectoryNotFoundException($"Context directory not found: {contextDir}");
-        }
+        Directory.CreateDirectory(contextDir);
 
         var preDir = Path.Combine(contextDir, "pre");
         var postDir = Path.Combine(contextDir, "post");
 
         if (!Directory.Exists(preDir))
         {
-            throw new DirectoryNotFoundException($"Pre-task directory not found: {preDir}");
+            Console.WriteLine($"Creating missing pre-task directory: {preDir}");
         }
-
         if (!Directory.Exists(postDir))
         {
-            throw new DirectoryNotFoundException($"Post-task directory not found: {postDir}");
+            Console.WriteLine($"Creating missing post-task directory: {postDir}");
         }
+
+        // ensure context subdirectories exist so automation continues even if
+        // repository is missing them. This mirrors 'mkdir -p' behaviour.
+        Directory.CreateDirectory(preDir);
+        Directory.CreateDirectory(postDir);
 
         foreach (var file in Directory.EnumerateFiles(sourceDir, "*.md", SearchOption.TopDirectoryOnly).OrderBy(f => f))
         {

--- a/docs/deliverables/codex-automation.md
+++ b/docs/deliverables/codex-automation.md
@@ -8,7 +8,8 @@ The Codex automation processes tasks under `docs/tasks`. For each normal task fi
 2. Executes the normal task file.
 3. Runs all post-task markdown files from `tasks/context/post/` in sorted order.
 
-Pre- and post-task directories must exist. If either is missing, the automation fails with a clear `DirectoryNotFoundException` message.
+The automation ensures the context directories exist. If either `tasks/context/pre/` or
+`tasks/context/post/` is missing, it is automatically created so processing can continue.
 
 Files anywhere under `tasks/context` are never moved to `tasks/implemented`.
 

--- a/tests/Synthea.Cli.UnitTests/CodexTaskProcessorTests.cs
+++ b/tests/Synthea.Cli.UnitTests/CodexTaskProcessorTests.cs
@@ -99,21 +99,22 @@ public class CodexTaskProcessorTests : IDisposable
     }
 
     [Fact]
-    public void ThrowsIfPreDirMissing()
+    public void CreatesMissingContextDirsAndMovesFile()
     {
         Directory.Delete(_preDir, true);
-        var ex = Assert.Throws<DirectoryNotFoundException>(() =>
-            CodexTaskProcessor.ProcessTasks(_src, _dest, new StubImplementer(true)));
-        Assert.Contains("Pre-task directory", ex.Message);
-    }
-
-    [Fact]
-    public void ThrowsIfPostDirMissing()
-    {
         Directory.Delete(_postDir, true);
-        var ex = Assert.Throws<DirectoryNotFoundException>(() =>
-            CodexTaskProcessor.ProcessTasks(_src, _dest, new StubImplementer(true)));
-        Assert.Contains("Post-task directory", ex.Message);
+        var file = Path.Combine(_src, "task.md");
+        File.WriteAllText(file, "t");
+
+        var impl = new StubImplementer(success: true);
+        CodexTaskProcessor.ProcessTasks(_src, _dest, impl);
+
+        Assert.True(Directory.Exists(_preDir));
+        Assert.True(Directory.Exists(_postDir));
+
+        Assert.False(File.Exists(file));
+        var moved = Directory.GetFiles(_dest).Single();
+        Assert.Matches("^\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}-task\\.md$", Path.GetFileName(moved));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- make automation create missing context directories
- log creation of pre/post directories
- update docs to explain auto-creation
- adjust tests to verify files move when directories are missing

## Testing
- `dotnet test --verbosity minimal`
- custom run of automation on docs tasks