### PR TITLE
Ensure staged artefacts directory persists and run tests sequentially

### DIFF
--- a/src/Synthea.Cli/CodexTaskProcessor.cs
+++ b/src/Synthea.Cli/CodexTaskProcessor.cs
@@ -88,6 +88,8 @@ public static class CodexTaskProcessor
                     var baseName = Path.GetFileNameWithoutExtension(name).Replace(' ', '_');
                     var logName = $"{prefix}-{baseName}-log.md";
                     var fbName  = $"{prefix}-{baseName}-feedback.md";
+                    // Re-create the staged directory in case an earlier task removed it
+                    Directory.CreateDirectory(stagedDir);
                     var logPath = GetUniqueFilePath(stagedDir, logName);
                     var fbPath  = GetUniqueFilePath(stagedDir, fbName);
 

--- a/tests/Synthea.Cli.UnitTests/AssemblyInfo.cs
+++ b/tests/Synthea.Cli.UnitTests/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+using Xunit;
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
## Summary
- Recreate the tasks/staged directory before writing log and feedback artefacts
- Disable test parallelization to avoid temp-directory races between unit tests

## Testing
- `dotnet test --no-build tests/Synthea.Cli.UnitTests/Synthea.Cli.UnitTests.csproj`
- `dotnet test --no-build tests/Synthea.Cli.IntegrationTests/Synthea.Cli.IntegrationTests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68967f75063c832d9f2f656105210180