### PR TITLE
feat(deps): migrate System.CommandLine to 2.0.x GA (A-15)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,12 +19,6 @@ updates:
           - "xunit*"
           - "Microsoft.NET.Test.Sdk"
           - "coverlet.*"
-    ignore:
-      # The 2.0.0-beta4 -> 2.0.x GA jump rewrites the InvocationContext /
-      # SetHandler / GetValueForOption / IsRequired API surface used in
-      # RunCommand.cs. Tracked separately as design-review finding A-15;
-      # remove this entry when that migration commit lands.
-      - dependency-name: "System.CommandLine"
 
   - package-ecosystem: github-actions
     directory: /

--- a/src/Synthea.Cli/Program.cs
+++ b/src/Synthea.Cli/Program.cs
@@ -20,21 +20,24 @@ internal static class Program
 
         var root = new RootCommand("CLI wrapper around MITRE Synthea synthetic patient generator");
 
-        var refreshOpt = new Option<bool>(
-            "--refresh",
-            "Ignore cached JAR and download the newest release");
+        var refreshOpt = new Option<bool>("--refresh")
+        {
+            Description = "Ignore cached JAR and download the newest release",
+            Recursive = true
+        };
 
-        var javaOpt = new Option<string?>(
-            "--java-path",
-            () => null,
-            "Full path to the Java executable (defaults to 'java' on PATH)");
+        var javaOpt = new Option<string?>("--java-path")
+        {
+            Description = "Full path to the Java executable (defaults to 'java' on PATH)",
+            Recursive = true
+        };
 
-        root.AddGlobalOption(refreshOpt);
-        root.AddGlobalOption(javaOpt);
+        root.Options.Add(refreshOpt);
+        root.Options.Add(javaOpt);
 
-        root.AddCommand(RunCommand.Build(refreshOpt, javaOpt));
+        root.Subcommands.Add(RunCommand.Build(refreshOpt, javaOpt));
 
         if (args.Length == 0) args = new[] { "--help" };
-        return await root.InvokeAsync(args);
+        return await root.Parse(args).InvokeAsync();
     }
 }

--- a/src/Synthea.Cli/RunCommand.cs
+++ b/src/Synthea.Cli/RunCommand.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.Diagnostics;
 using System.IO;
@@ -24,10 +23,11 @@ internal static class RunCommand
     {
         var runCmd = new Command("run", "Generate synthetic health records");
 
-        var outputOpt = new Option<DirectoryInfo>(
-            aliases: new[] { "--output", "-o" },
-            description: "Directory where Synthea will write its output")
-        { IsRequired = true };
+        var outputOpt = new Option<DirectoryInfo>("--output", "-o")
+        {
+            Description = "Directory where Synthea will write its output",
+            Required = true
+        };
 
         var stateOpt = CreateStateOption();
         var cityOpt = CreateCityOption();
@@ -44,58 +44,55 @@ internal static class RunCommand
         var updatedSnapOpt = CreateUpdatedSnapshotOption();
         var daysForwardOpt = CreateDaysForwardOption();
         var formatOpt = CreateFormatOption();
-        var printArgsOpt = new Option<bool>(
-            "--print-args",
-            "Print the java command line that would be run, then exit without running it. " +
-            "Useful for debugging or scripting. Does not download the JAR.");
+        var printArgsOpt = new Option<bool>("--print-args")
+        {
+            Description = "Print the java command line that would be run, then exit without running it. " +
+                          "Useful for debugging or scripting. Does not download the JAR."
+        };
         var passthru = CreatePassthruArgument();
 
-        runCmd.AddOption(outputOpt);
-        runCmd.AddOption(stateOpt);
-        runCmd.AddOption(cityOpt);
-        runCmd.AddOption(genderOpt);
-        runCmd.AddOption(ageOpt);
-        runCmd.AddOption(moduleDirOpt);
-        runCmd.AddOption(moduleOpt);
-        runCmd.AddOption(popOpt);
-        runCmd.AddOption(seedOpt);
-        runCmd.AddOption(configOpt);
-        runCmd.AddOption(zipOpt);
-        runCmd.AddOption(fhirVerOpt);
-        runCmd.AddOption(initialSnapOpt);
-        runCmd.AddOption(updatedSnapOpt);
-        runCmd.AddOption(daysForwardOpt);
-        runCmd.AddOption(formatOpt);
-        runCmd.AddOption(printArgsOpt);
-        runCmd.AddArgument(passthru);
+        runCmd.Options.Add(outputOpt);
+        runCmd.Options.Add(stateOpt);
+        runCmd.Options.Add(cityOpt);
+        runCmd.Options.Add(genderOpt);
+        runCmd.Options.Add(ageOpt);
+        runCmd.Options.Add(moduleDirOpt);
+        runCmd.Options.Add(moduleOpt);
+        runCmd.Options.Add(popOpt);
+        runCmd.Options.Add(seedOpt);
+        runCmd.Options.Add(configOpt);
+        runCmd.Options.Add(zipOpt);
+        runCmd.Options.Add(fhirVerOpt);
+        runCmd.Options.Add(initialSnapOpt);
+        runCmd.Options.Add(updatedSnapOpt);
+        runCmd.Options.Add(daysForwardOpt);
+        runCmd.Options.Add(formatOpt);
+        runCmd.Options.Add(printArgsOpt);
+        runCmd.Arguments.Add(passthru);
 
         runCmd.TreatUnmatchedTokensAsErrors = false;
 
-        runCmd.SetHandler(async (InvocationContext ctx) =>
+        runCmd.SetAction(async (ParseResult parseResult, CancellationToken cancelToken) =>
         {
-            var opts = ParseRunOptions(ctx, refreshOpt, javaOpt, outputOpt, stateOpt, cityOpt,
+            var opts = ParseRunOptions(parseResult, refreshOpt, javaOpt, outputOpt, stateOpt, cityOpt,
                 genderOpt, ageOpt, moduleDirOpt, moduleOpt, popOpt, seedOpt, configOpt, zipOpt,
                 fhirVerOpt, initialSnapOpt, updatedSnapOpt, daysForwardOpt, formatOpt, passthru);
-            var printArgs = ctx.ParseResult.GetValueForOption(printArgsOpt);
-            var cancelToken = ctx.GetCancellationToken();
+            var printArgs = parseResult.GetValue(printArgsOpt);
 
             if (!string.IsNullOrWhiteSpace(opts.City) && string.IsNullOrWhiteSpace(opts.State))
             {
                 Console.Error.WriteLine("--city requires --state to be specified.");
-                ctx.ExitCode = 1;
-                return;
+                return 1;
             }
             if (!string.IsNullOrWhiteSpace(opts.Zip) && string.IsNullOrWhiteSpace(opts.State))
             {
                 Console.Error.WriteLine("--zip requires --state to be specified.");
-                ctx.ExitCode = 1;
-                return;
+                return 1;
             }
 
             if (printArgs)
             {
-                ctx.ExitCode = PrintInvocation(opts);
-                return;
+                return PrintInvocation(opts);
             }
 
             Directory.CreateDirectory(opts.Output.FullName);
@@ -126,33 +123,33 @@ internal static class RunCommand
                 var pumpErr = Task.Run(() => ProcessHelpers.Relay(proc.StandardError, Console.Error));
 
                 await Task.WhenAll(pumpOut, pumpErr, proc.WaitForExitAsync());
-                ctx.ExitCode = proc.ExitCode;
+                return proc.ExitCode;
             }
             catch (OperationCanceledException)
             {
                 Console.Error.WriteLine("Cancelled.");
-                ctx.ExitCode = 130; // conventional SIGINT exit code
+                return 130; // conventional SIGINT exit code
             }
             catch (HttpRequestException ex)
             {
                 Console.Error.WriteLine($"Network error reaching GitHub: {ex.Message}");
                 Console.Error.WriteLine("Check your connection, proxy, or GitHub API rate limits.");
-                ctx.ExitCode = 3;
+                return 3;
             }
             catch (InvalidOperationException ex)
             {
                 Console.Error.WriteLine($"Synthea JAR error: {ex.Message}");
-                ctx.ExitCode = 3;
+                return 3;
             }
             catch (IOException ex)
             {
                 Console.Error.WriteLine($"Filesystem error: {ex.Message}");
-                ctx.ExitCode = 2;
+                return 2;
             }
             catch (Exception ex)
             {
                 Console.Error.WriteLine($"Unexpected error ({ex.GetType().Name}): {ex.Message}");
-                ctx.ExitCode = 4;
+                return 4;
             }
         });
 
@@ -288,7 +285,7 @@ internal static class RunCommand
         return "\"" + s.Replace("\"", "\\\"") + "\"";
     }
 
-    private static RunOptions ParseRunOptions(InvocationContext ctx,
+    private static RunOptions ParseRunOptions(ParseResult parseResult,
         Option<bool> refreshOpt,
         Option<string?> javaOpt,
         Option<DirectoryInfo> outputOpt,
@@ -309,49 +306,51 @@ internal static class RunCommand
         Option<string[]> formatOpt,
         Argument<string[]> passthru)
     {
-        var javaPathArg = ctx.ParseResult.GetValueForOption(javaOpt);
+        var javaPathArg = parseResult.GetValue(javaOpt);
         return new RunOptions(
-            Output: ctx.ParseResult.GetValueForOption(outputOpt)!,
-            Refresh: ctx.ParseResult.GetValueForOption(refreshOpt),
+            Output: parseResult.GetValue(outputOpt)!,
+            Refresh: parseResult.GetValue(refreshOpt),
             JavaPath: string.IsNullOrWhiteSpace(javaPathArg) ? "java" : javaPathArg!,
-            State: ctx.ParseResult.GetValueForOption(stateOpt),
-            City: ctx.ParseResult.GetValueForOption(cityOpt),
-            Gender: ctx.ParseResult.GetValueForOption(genderOpt),
-            AgeRange: ctx.ParseResult.GetValueForOption(ageOpt),
-            ModuleDir: ctx.ParseResult.GetValueForOption(moduleDirOpt),
-            Modules: ctx.ParseResult.GetValueForOption(moduleOpt),
-            Population: ctx.ParseResult.GetValueForOption(popOpt),
-            Seed: ctx.ParseResult.GetValueForOption(seedOpt),
-            Config: ctx.ParseResult.GetValueForOption(configOpt),
-            Zip: ctx.ParseResult.GetValueForOption(zipOpt),
-            FhirVersion: ctx.ParseResult.GetValueForOption(fhirOpt),
-            InitialSnapshot: ctx.ParseResult.GetValueForOption(initSnapOpt),
-            UpdatedSnapshot: ctx.ParseResult.GetValueForOption(updSnapOpt),
-            DaysForward: ctx.ParseResult.GetValueForOption(daysOpt),
-            Formats: ctx.ParseResult.GetValueForOption(formatOpt) ?? Array.Empty<string>(),
-            Passthru: ctx.ParseResult.GetValueForArgument(passthru));
+            State: parseResult.GetValue(stateOpt),
+            City: parseResult.GetValue(cityOpt),
+            Gender: parseResult.GetValue(genderOpt),
+            AgeRange: parseResult.GetValue(ageOpt),
+            ModuleDir: parseResult.GetValue(moduleDirOpt),
+            Modules: parseResult.GetValue(moduleOpt),
+            Population: parseResult.GetValue(popOpt),
+            Seed: parseResult.GetValue(seedOpt),
+            Config: parseResult.GetValue(configOpt),
+            Zip: parseResult.GetValue(zipOpt),
+            FhirVersion: parseResult.GetValue(fhirOpt),
+            InitialSnapshot: parseResult.GetValue(initSnapOpt),
+            UpdatedSnapshot: parseResult.GetValue(updSnapOpt),
+            DaysForward: parseResult.GetValue(daysOpt),
+            Formats: parseResult.GetValue(formatOpt) ?? Array.Empty<string>(),
+            Passthru: parseResult.GetValue(passthru) ?? Array.Empty<string>());
     }
 
     // ----- Option-validator helpers ---------------------------------------
     //
     // Every Create*Option method below shares the same pattern: "if a value
-    // was supplied, run a check and set r.ErrorMessage when it fails." Two
-    // helpers fold that pattern away so each option declaration shows only
-    // the rule itself, not the boilerplate around it.
+    // was supplied, run a check and add an error when it fails." Two helpers
+    // fold that pattern away so each option declaration shows only the rule
+    // itself. In System.CommandLine 2.0 GA the validator delegate is
+    // Action<OptionResult> — the beta-era named ValidateSymbolResult<T>
+    // type is gone (notes §5.4 gotcha).
 
-    private static ValidateSymbolResult<OptionResult> SingleTokenValidator(Func<string, string?> check) => r =>
+    private static Action<OptionResult> SingleTokenValidator(Func<string, string?> check) => r =>
     {
         if (r.Tokens.Count == 0) return;
         var err = check(r.Tokens[0].Value);
-        if (err is not null) r.ErrorMessage = err;
+        if (err is not null) r.AddError(err);
     };
 
-    private static ValidateSymbolResult<OptionResult> MultiTokenValidator(Func<string, string?> check) => r =>
+    private static Action<OptionResult> MultiTokenValidator(Func<string, string?> check) => r =>
     {
         foreach (var t in r.Tokens)
         {
             var err = check(t.Value);
-            if (err is not null) { r.ErrorMessage = err; return; }
+            if (err is not null) { r.AddError(err); return; }
         }
     };
 
@@ -363,25 +362,27 @@ internal static class RunCommand
         // allowlist silently rejected DC, PR, GU, VI, and any future
         // Synthea-supported geo codes. Defer the "is this a real place?"
         // check to Synthea itself, which owns the geo data.
-        var opt = new Option<string?>("--state",
-            "Two-letter state/territory code (e.g. OH, TX, DC, PR). Format-only check; Synthea rejects unknown codes itself.");
-        opt.AddValidator(SingleTokenValidator(v =>
+        var opt = new Option<string?>("--state")
+        {
+            Description = "Two-letter state/territory code (e.g. OH, TX, DC, PR). Format-only check; Synthea rejects unknown codes itself."
+        };
+        opt.Validators.Add(SingleTokenValidator(v =>
             v.Length == 2 && v.All(char.IsLetter) ? null : "State code must be exactly two letters."));
         return opt;
     }
 
     private static Option<string?> CreateCityOption()
     {
-        var opt = new Option<string?>("--city", "City name (optional second positional arg after state)");
-        opt.AddValidator(SingleTokenValidator(v =>
+        var opt = new Option<string?>("--city") { Description = "City name (optional second positional arg after state)" };
+        opt.Validators.Add(SingleTokenValidator(v =>
             string.IsNullOrWhiteSpace(v) ? "City name cannot be empty." : null));
         return opt;
     }
 
     private static Option<string?> CreateGenderOption()
     {
-        var opt = new Option<string?>("--gender", "Patient gender filter (M or F)");
-        opt.AddValidator(SingleTokenValidator(v =>
+        var opt = new Option<string?>("--gender") { Description = "Patient gender filter (M or F)" };
+        opt.Validators.Add(SingleTokenValidator(v =>
         {
             var g = v.ToUpperInvariant();
             return g == "M" || g == "F" ? null : "Gender must be 'M' or 'F'.";
@@ -391,8 +392,8 @@ internal static class RunCommand
 
     private static Option<string?> CreateAgeRangeOption()
     {
-        var opt = new Option<string?>("--age-range", "Age range filter as min-max");
-        opt.AddValidator(SingleTokenValidator(v =>
+        var opt = new Option<string?>("--age-range") { Description = "Age range filter as min-max" };
+        opt.Validators.Add(SingleTokenValidator(v =>
         {
             var parts = v.Split('-', 2);
             return parts.Length == 2
@@ -407,56 +408,60 @@ internal static class RunCommand
 
     private static Option<DirectoryInfo?> CreateModuleDirOption()
     {
-        var opt = new Option<DirectoryInfo?>("--module-dir", "Directory of custom modules");
-        opt.AddValidator(SingleTokenValidator(v =>
+        var opt = new Option<DirectoryInfo?>("--module-dir") { Description = "Directory of custom modules" };
+        opt.Validators.Add(SingleTokenValidator(v =>
             Directory.Exists(v) ? null : "Module directory does not exist."));
         return opt;
     }
 
     private static Option<string[]> CreateModuleOption()
     {
-        var opt = new Option<string[]>("--module", "Specific disease modules") { Arity = ArgumentArity.ZeroOrMore };
-        opt.AddValidator(MultiTokenValidator(v =>
+        var opt = new Option<string[]>("--module")
+        {
+            Description = "Specific disease modules",
+            Arity = ArgumentArity.ZeroOrMore
+        };
+        opt.Validators.Add(MultiTokenValidator(v =>
             string.IsNullOrWhiteSpace(v) ? "Module name cannot be empty." : null));
         return opt;
     }
 
     private static Option<int?> CreatePopulationOption()
     {
-        var opt = new Option<int?>(aliases: new[] { "--population", "-p" }, description: "Number of patients to generate");
-        opt.AddValidator(SingleTokenValidator(v =>
+        var opt = new Option<int?>("--population", "-p") { Description = "Number of patients to generate" };
+        opt.Validators.Add(SingleTokenValidator(v =>
             int.TryParse(v, out var n) && n > 0 ? null : "Population must be a positive integer."));
         return opt;
     }
 
     private static Option<int?> CreateSeedOption()
     {
-        var opt = new Option<int?>(aliases: new[] { "--seed", "-s" }, description: "Random seed for deterministic output");
-        opt.AddValidator(SingleTokenValidator(v =>
+        var opt = new Option<int?>("--seed", "-s") { Description = "Random seed for deterministic output" };
+        opt.Validators.Add(SingleTokenValidator(v =>
             int.TryParse(v, out _) ? null : "Random seed must be an integer."));
         return opt;
     }
 
     private static Option<FileInfo?> CreateConfigOption()
     {
-        var opt = new Option<FileInfo?>(aliases: new[] { "--config", "-c" }, description: "Path to Synthea configuration file");
-        opt.AddValidator(SingleTokenValidator(v =>
+        var opt = new Option<FileInfo?>("--config", "-c") { Description = "Path to Synthea configuration file" };
+        opt.Validators.Add(SingleTokenValidator(v =>
             File.Exists(v) ? null : "Configuration file does not exist."));
         return opt;
     }
 
     private static Option<string?> CreateZipOption()
     {
-        var opt = new Option<string?>("--zip", "ZIP code (requires --state)");
-        opt.AddValidator(SingleTokenValidator(v =>
+        var opt = new Option<string?>("--zip") { Description = "ZIP code (requires --state)" };
+        opt.Validators.Add(SingleTokenValidator(v =>
             Regex.IsMatch(v, @"^\d{5}(?:-\d{4})?$") ? null : "ZIP code must be 5 digits or 5+4."));
         return opt;
     }
 
     private static Option<string?> CreateFhirVersionOption()
     {
-        var opt = new Option<string?>("--fhir-version", "FHIR version (R4 or STU3)");
-        opt.AddValidator(SingleTokenValidator(v =>
+        var opt = new Option<string?>("--fhir-version") { Description = "FHIR version (R4 or STU3)" };
+        opt.Validators.Add(SingleTokenValidator(v =>
         {
             var u = v.ToUpperInvariant();
             return u == "R4" || u == "STU3" ? null : "FHIR version must be R4 or STU3.";
@@ -466,16 +471,16 @@ internal static class RunCommand
 
     private static Option<FileInfo?> CreateInitialSnapshotOption()
     {
-        var opt = new Option<FileInfo?>("--initial-snapshot", "Path to initial snapshot to load (-i)");
-        opt.AddValidator(SingleTokenValidator(v =>
+        var opt = new Option<FileInfo?>("--initial-snapshot") { Description = "Path to initial snapshot to load (-i)" };
+        opt.Validators.Add(SingleTokenValidator(v =>
             File.Exists(v) ? null : "Initial snapshot file does not exist."));
         return opt;
     }
 
     private static Option<FileInfo?> CreateUpdatedSnapshotOption()
     {
-        var opt = new Option<FileInfo?>("--updated-snapshot", "Path where updated snapshot will be written (-u)");
-        opt.AddValidator(SingleTokenValidator(v =>
+        var opt = new Option<FileInfo?>("--updated-snapshot") { Description = "Path where updated snapshot will be written (-u)" };
+        opt.Validators.Add(SingleTokenValidator(v =>
         {
             var dir = Path.GetDirectoryName(v);
             return !string.IsNullOrWhiteSpace(dir) && Directory.Exists(dir)
@@ -487,18 +492,20 @@ internal static class RunCommand
 
     private static Option<int?> CreateDaysForwardOption()
     {
-        var opt = new Option<int?>("--days-forward", "Advance time from snapshot by N days (-t)");
-        opt.AddValidator(SingleTokenValidator(v =>
+        var opt = new Option<int?>("--days-forward") { Description = "Advance time from snapshot by N days (-t)" };
+        opt.Validators.Add(SingleTokenValidator(v =>
             int.TryParse(v, out var n) && n > 0 ? null : "Days forward must be a positive integer."));
         return opt;
     }
 
     private static Option<string[]> CreateFormatOption()
     {
-        var opt = new Option<string[]>("--format",
-            "Output formats to generate (FHIR, CSV, CCDA, BULKFHIR, CPCDS)")
-        { Arity = ArgumentArity.ZeroOrMore };
-        opt.AddValidator(MultiTokenValidator(v =>
+        var opt = new Option<string[]>("--format")
+        {
+            Description = "Output formats to generate (FHIR, CSV, CCDA, BULKFHIR, CPCDS)",
+            Arity = ArgumentArity.ZeroOrMore
+        };
+        opt.Validators.Add(MultiTokenValidator(v =>
             AllowedFormats.Contains(v) ? null : $"Unsupported format '{v}'."));
         return opt;
     }

--- a/src/Synthea.Cli/Synthea.Cli.csproj
+++ b/src/Synthea.Cli/Synthea.Cli.csproj
@@ -24,8 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Add System.CommandLine prerelease for CLI parsing -->
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Synthea.Cli.UnitTests/ProgramRefactorTests.cs
+++ b/tests/Synthea.Cli.UnitTests/ProgramRefactorTests.cs
@@ -1,5 +1,9 @@
+using System;
 using System.IO;
 using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Linq;
 using Synthea.Cli;
 using Xunit;
 
@@ -7,6 +11,32 @@ namespace Synthea.Cli.UnitTests;
 
 public class ProgramRefactorTests
 {
+    // Regression guard for notes §5.4: in System.CommandLine 2.0 GA the
+    // validator delegate is Action<OptionResult>. The beta-era named
+    // ValidateSymbolResult<T> type was removed; a relapse to a beta-style
+    // signature would not even compile, but this test pins the contract
+    // so a future bump doesn't silently change it under us.
+    [Fact]
+    public void RunCommand_Validators_UseActionOptionResultDelegate()
+    {
+        var refreshOpt = new Option<bool>("--refresh");
+        var javaOpt = new Option<string?>("--java-path");
+        var run = RunCommand.Build(refreshOpt, javaOpt);
+
+        var stateOpt = run.Options.Single(o => o.Name == "--state");
+        Assert.NotEmpty(stateOpt.Validators);
+        foreach (var v in stateOpt.Validators)
+        {
+            Assert.IsType<Action<OptionResult>>(v);
+        }
+
+        // Sanity: the named delegate from the beta API must not exist on
+        // any validator. If a future bump reintroduces a named delegate
+        // and we accidentally type-annotate against it, this catches it.
+        var beta = Type.GetType("System.CommandLine.Parsing.ValidateSymbolResult`1, System.CommandLine");
+        Assert.Null(beta);
+    }
+
     [Fact]
     public void BuildArgumentList_BuildsExpectedFlags()
     {


### PR DESCRIPTION
## Summary
- Bumps `System.CommandLine` from `2.0.0-beta4` to `2.0.8` (GA).
- Rewrites `RunCommand.cs` and `Program.cs` for the GA API surface: `SetAction` over `SetHandler`, `ParseResult.GetValue` over `GetValueForOption/GetValueForArgument`, `Option<T>` name+aliases ctor, `Required` over `IsRequired`, `Validators.Add(Action<OptionResult>)` and `r.AddError(...)`. The beta-era named delegate `ValidateSymbolResult<T>` is gone in GA (notes §5.4 gotcha).
- Adds `ProgramRefactorTests.RunCommand_Validators_UseActionOptionResultDelegate` as a regression guard pinning the GA delegate contract.
- Drops the `System.CommandLine` ignore entry from `.github/dependabot.yml` so Dependabot resumes tracking it.

Closes A-15.

## Test plan
- [x] `dotnet build` clean (warnings-as-errors)
- [x] `dotnet test --no-build` — 38 unit tests + 4 integration tests pass
- [x] `dotnet format --verify-no-changes --severity warn` clean
- [ ] CI green on master after merge