### PR TITLE
ci: add windows-latest to test matrix (A-2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - name: Setup .NET
@@ -29,6 +33,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-cobertura
+          name: coverage-cobertura-${{ matrix.os }}
           path: TestResults/**/coverage.cobertura.xml
           if-no-files-found: warn


### PR DESCRIPTION
## Summary
- Splits the build job across `ubuntu-latest` and `windows-latest`.
- Distinguishes the coverage-artifact name per matrix leg so the upload step doesn't collide.

Closes A-2.

## Test plan
- [ ] Both `build (ubuntu-latest)` and `build (windows-latest)` legs go green on this PR
- [x] Local `dotnet build` + `dotnet test --no-build` still pass (no source changes)
- [ ] master CI green after merge

Gate class: workflow — coverage gate is N/A (no source change).