### PR TITLE
ci: enforce 80% line / 75% branch coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,17 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --warnaserror
       - name: Run Unit Tests (with coverage gate)
+        # NOTE: commas in MSBuild property values must be escaped as %2C
+        # so the shell doesn't split "80,75" into two arguments. Both
+        # bash (Linux) and pwsh (Windows) strip embedded quotes here.
         run: >-
           dotnet test tests/Synthea.Cli.UnitTests/Synthea.Cli.UnitTests.csproj
           --no-build --filter "Category!=Integration"
           -p:CollectCoverage=true
           -p:CoverletOutputFormat=cobertura
           -p:CoverletOutput=${{ github.workspace }}/TestResults/coverage.cobertura.xml
-          "-p:Threshold=80,75"
-          "-p:ThresholdType=line,branch"
+          -p:Threshold=80%2C75
+          -p:ThresholdType=line%2Cbranch
           -p:ThresholdStat=total
       - name: Run Integration Tests
         run: dotnet test --no-build --filter Category=Integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,16 @@ jobs:
         run: dotnet format --no-restore --verify-no-changes --severity warn
       - name: Build
         run: dotnet build --no-restore --warnaserror
-      - name: Run Unit Tests
-        run: dotnet test --no-build --filter Category!=Integration --collect:"XPlat Code Coverage" --results-directory TestResults
+      - name: Run Unit Tests (with coverage gate)
+        run: >-
+          dotnet test tests/Synthea.Cli.UnitTests/Synthea.Cli.UnitTests.csproj
+          --no-build --filter "Category!=Integration"
+          -p:CollectCoverage=true
+          -p:CoverletOutputFormat=cobertura
+          -p:CoverletOutput=${{ github.workspace }}/TestResults/coverage.cobertura.xml
+          "-p:Threshold=80,75"
+          "-p:ThresholdType=line,branch"
+          -p:ThresholdStat=total
       - name: Run Integration Tests
         run: dotnet test --no-build --filter Category=Integration
       - name: Upload coverage report
@@ -34,5 +42,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: coverage-cobertura-${{ matrix.os }}
-          path: TestResults/**/coverage.cobertura.xml
+          path: TestResults/coverage.cobertura.xml
           if-no-files-found: warn

--- a/tests/Synthea.Cli.UnitTests/Synthea.Cli.UnitTests.csproj
+++ b/tests/Synthea.Cli.UnitTests/Synthea.Cli.UnitTests.csproj
@@ -13,6 +13,10 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.0" />
+    <PackageReference Include="coverlet.msbuild" Version="10.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
## Summary
- Adds `coverlet.msbuild 10.0.0` to `Synthea.Cli.UnitTests` and wires the unit-test CI step with `-p:Threshold=80,75 -p:ThresholdType=line,branch -p:ThresholdStat=total`.
- Locks the baseline coverage (line 85.3% / branch 80.31%) above an 80/75 floor so future refactors can't dip silently.

Closes notes Section 6.2 (coverage threshold gate leftover).

## Verification
Local dry-run on master at this branch:
- `Threshold=99 ThresholdType=line` -> exit **1** with `The total line coverage is below the specified 99`.
- `Threshold=80,75 ThresholdType=line,branch` -> exit **0** (baseline 85.3% / 80.31% passes the gate).

## Test plan
- [ ] CI green on both `build (ubuntu-latest)` and `build (windows-latest)` legs
- [x] Local gate at `80,75` passes
- [x] Local gate at `99` correctly trips with non-zero exit
- [ ] master CI green after merge

Gate class: workflow — coverage gate is N/A as a *gate* on this PR (this PR introduces it).