### PR TITLE
refactor: split RunOptions into HostingOptions + SyntheaArgs (A-28)

### DIFF
--- a/src/Synthea.Cli/HostingOptions.cs
+++ b/src/Synthea.Cli/HostingOptions.cs
@@ -1,0 +1,10 @@
+namespace Synthea.Cli;
+
+// Controls how the CLI hosts the Synthea run: where output lands, whether
+// to refresh the cached JAR, which Java executable to invoke. Kept
+// separate from SyntheaArgs so DI/composition layers can resolve hosting
+// concerns without dragging the domain argument surface along.
+internal record HostingOptions(
+    DirectoryInfo Output,
+    bool Refresh,
+    string JavaPath);

--- a/src/Synthea.Cli/RunCommand.cs
+++ b/src/Synthea.Cli/RunCommand.cs
@@ -74,17 +74,17 @@ internal static class RunCommand
 
         runCmd.SetAction(async (ParseResult parseResult, CancellationToken cancelToken) =>
         {
-            var opts = ParseRunOptions(parseResult, refreshOpt, javaOpt, outputOpt, stateOpt, cityOpt,
+            var (hosting, args) = ParseRunOptions(parseResult, refreshOpt, javaOpt, outputOpt, stateOpt, cityOpt,
                 genderOpt, ageOpt, moduleDirOpt, moduleOpt, popOpt, seedOpt, configOpt, zipOpt,
                 fhirVerOpt, initialSnapOpt, updatedSnapOpt, daysForwardOpt, formatOpt, passthru);
             var printArgs = parseResult.GetValue(printArgsOpt);
 
-            if (!string.IsNullOrWhiteSpace(opts.City) && string.IsNullOrWhiteSpace(opts.State))
+            if (!string.IsNullOrWhiteSpace(args.City) && string.IsNullOrWhiteSpace(args.State))
             {
                 Console.Error.WriteLine("--city requires --state to be specified.");
                 return 1;
             }
-            if (!string.IsNullOrWhiteSpace(opts.Zip) && string.IsNullOrWhiteSpace(opts.State))
+            if (!string.IsNullOrWhiteSpace(args.Zip) && string.IsNullOrWhiteSpace(args.State))
             {
                 Console.Error.WriteLine("--zip requires --state to be specified.");
                 return 1;
@@ -92,10 +92,10 @@ internal static class RunCommand
 
             if (printArgs)
             {
-                return PrintInvocation(opts);
+                return PrintInvocation(hosting, args);
             }
 
-            Directory.CreateDirectory(opts.Output.FullName);
+            Directory.CreateDirectory(hosting.Output.FullName);
 
             try
             {
@@ -107,12 +107,12 @@ internal static class RunCommand
                         Console.Write($"\rDownloading Synthea {p.dl / 1_000_000}/{p.total / 1_000_000} MB…");
                 });
 
-                var jar = await Program.EnsureJarAsyncFunc(opts.Refresh, progress, cancelToken);
+                var jar = await Program.EnsureJarAsyncFunc(hosting.Refresh, progress, cancelToken);
 
                 if (interactive) Console.WriteLine();
                 Console.WriteLine($"✓ Using {jar.Name}  ({jar.FullName})");
 
-                var psi = CreateProcessStartInfo(opts, jar);
+                var psi = CreateProcessStartInfo(hosting, args, jar);
 
                 using var proc = Program.Runner.Start(psi);
                 using var killReg = cancelToken.Register(() =>
@@ -156,7 +156,7 @@ internal static class RunCommand
         return runCmd;
     }
 
-    internal static List<string> BuildArgumentList(RunOptions o)
+    internal static List<string> BuildArgumentList(SyntheaArgs o)
     {
         var argList = new List<string>();
         if (o.Population.HasValue)
@@ -242,34 +242,34 @@ internal static class RunCommand
         return argList;
     }
 
-    internal static ProcessStartInfo CreateProcessStartInfo(RunOptions o, FileInfo jar)
+    internal static ProcessStartInfo CreateProcessStartInfo(HostingOptions hosting, SyntheaArgs args, FileInfo jar)
     {
-        var psi = new ProcessStartInfo(o.JavaPath)
+        var psi = new ProcessStartInfo(hosting.JavaPath)
         {
             UseShellExecute = false,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
-            WorkingDirectory = o.Output.FullName
+            WorkingDirectory = hosting.Output.FullName
         };
         psi.ArgumentList.Add("-jar");
         psi.ArgumentList.Add(jar.FullName);
-        foreach (var a in BuildArgumentList(o))
+        foreach (var a in BuildArgumentList(args))
             psi.ArgumentList.Add(a);
         return psi;
     }
 
-    private static int PrintInvocation(RunOptions o)
+    private static int PrintInvocation(HostingOptions hosting, SyntheaArgs args)
     {
         var cachedJar = JarManager.TryFindCachedJar();
         var jarLabel = cachedJar?.FullName
             ?? "<synthea.jar — not yet cached; run once without --print-args>";
-        Console.WriteLine($"# Java executable: {o.JavaPath}");
+        Console.WriteLine($"# Java executable: {hosting.JavaPath}");
         Console.WriteLine($"# Synthea JAR:     {jarLabel}");
-        Console.WriteLine($"# Working dir:     {o.Output.FullName}");
-        Console.Write(QuoteForShell(o.JavaPath));
+        Console.WriteLine($"# Working dir:     {hosting.Output.FullName}");
+        Console.Write(QuoteForShell(hosting.JavaPath));
         Console.Write(" -jar ");
         Console.Write(QuoteForShell(jarLabel));
-        foreach (var a in BuildArgumentList(o))
+        foreach (var a in BuildArgumentList(args))
         {
             Console.Write(' ');
             Console.Write(QuoteForShell(a));
@@ -285,7 +285,7 @@ internal static class RunCommand
         return "\"" + s.Replace("\"", "\\\"") + "\"";
     }
 
-    private static RunOptions ParseRunOptions(ParseResult parseResult,
+    private static (HostingOptions Hosting, SyntheaArgs Args) ParseRunOptions(ParseResult parseResult,
         Option<bool> refreshOpt,
         Option<string?> javaOpt,
         Option<DirectoryInfo> outputOpt,
@@ -307,10 +307,11 @@ internal static class RunCommand
         Argument<string[]> passthru)
     {
         var javaPathArg = parseResult.GetValue(javaOpt);
-        return new RunOptions(
+        var hosting = new HostingOptions(
             Output: parseResult.GetValue(outputOpt)!,
             Refresh: parseResult.GetValue(refreshOpt),
-            JavaPath: string.IsNullOrWhiteSpace(javaPathArg) ? "java" : javaPathArg!,
+            JavaPath: string.IsNullOrWhiteSpace(javaPathArg) ? "java" : javaPathArg!);
+        var args = new SyntheaArgs(
             State: parseResult.GetValue(stateOpt),
             City: parseResult.GetValue(cityOpt),
             Gender: parseResult.GetValue(genderOpt),
@@ -327,6 +328,7 @@ internal static class RunCommand
             DaysForward: parseResult.GetValue(daysOpt),
             Formats: parseResult.GetValue(formatOpt) ?? Array.Empty<string>(),
             Passthru: parseResult.GetValue(passthru) ?? Array.Empty<string>());
+        return (hosting, args);
     }
 
     // ----- Option-validator helpers ---------------------------------------

--- a/src/Synthea.Cli/SyntheaArgs.cs
+++ b/src/Synthea.Cli/SyntheaArgs.cs
@@ -1,9 +1,9 @@
 namespace Synthea.Cli;
 
-internal record RunOptions(
-    DirectoryInfo Output,
-    bool Refresh,
-    string JavaPath,
+// Everything that maps to flags or positional values Synthea itself
+// consumes. BuildArgumentList depends only on this; nothing about
+// hosting (java path, output dir, refresh) belongs here.
+internal record SyntheaArgs(
     string? State,
     string? City,
     string? Gender,

--- a/tests/Synthea.Cli.UnitTests/ProgramRefactorTests.cs
+++ b/tests/Synthea.Cli.UnitTests/ProgramRefactorTests.cs
@@ -40,10 +40,7 @@ public class ProgramRefactorTests
     [Fact]
     public void BuildArgumentList_BuildsExpectedFlags()
     {
-        var opts = new RunOptions(
-            Output: new DirectoryInfo("/tmp"),
-            Refresh: false,
-            JavaPath: "java",
+        var args = new SyntheaArgs(
             State: "OH",
             City: "Cleveland",
             Gender: "M",
@@ -61,7 +58,7 @@ public class ProgramRefactorTests
             Formats: new[] { "fhir" },
             Passthru: new[] { "--extra" });
 
-        var list = RunCommand.BuildArgumentList(opts);
+        var list = RunCommand.BuildArgumentList(args);
         Assert.Contains("-p", list);
         Assert.Contains("5", list);
         Assert.Contains("-s", list);
@@ -88,10 +85,11 @@ public class ProgramRefactorTests
     public void CreateProcessStartInfo_UsesWorkingDirectoryAndJar()
     {
         var tmpDir = Path.Combine(Path.GetTempPath(), "synthea-test-tmp");
-        var opts = new RunOptions(
+        var hosting = new HostingOptions(
             Output: new DirectoryInfo(tmpDir),
             Refresh: false,
-            JavaPath: "customjava",
+            JavaPath: "customjava");
+        var args = new SyntheaArgs(
             State: null,
             City: null,
             Gender: null,
@@ -110,7 +108,7 @@ public class ProgramRefactorTests
             Passthru: System.Array.Empty<string>());
 
         var jar = new FileInfo(Path.Combine(tmpDir, "synthea.jar"));
-        var psi = RunCommand.CreateProcessStartInfo(opts, jar);
+        var psi = RunCommand.CreateProcessStartInfo(hosting, args, jar);
         Assert.Equal("customjava", psi.FileName);
         Assert.Equal(tmpDir, psi.WorkingDirectory);
         Assert.Contains("-jar", psi.ArgumentList);


### PR DESCRIPTION
## Summary
- Splits the immutable `RunOptions` record into two purpose-aligned records:
  - `HostingOptions` — `Output`, `Refresh`, `JavaPath` (controls *how* the CLI hosts the Synthea run).
  - `SyntheaArgs` — domain-level arguments (state, city, gender, modules, formats, passthru, etc.) that map onto Synthea CLI flags.
- `RunCommand.ParseRunOptions` returns `(HostingOptions, SyntheaArgs)`; `CreateProcessStartInfo` and `PrintInvocation` take both. `BuildArgumentList` depends only on `SyntheaArgs`.
- No behavior change.

Closes A-28.

## Test plan
- [x] `dotnet build` clean
- [x] 38 unit tests + 4 integration tests pass
- [x] Local coverage gate `Threshold=80,75 ThresholdType=line,branch` passes (85.38% / 80.31%)
- [ ] CI green on both `build` legs (ubuntu + windows)
- [ ] master CI green after merge