### PR TITLE
fix(run): emit passthru tokens after positional state/city/zip (A-9)

### DIFF
--- a/src/Synthea.Cli/RunCommand.cs
+++ b/src/Synthea.Cli/RunCommand.cs
@@ -234,10 +234,13 @@ internal static class RunCommand
                 argList.Add("--" + kv.Value + "=" + (enable ? "true" : "false"));
             }
         }
-        argList.AddRange(o.Passthru);
+        // Positional state/city/zip must precede passthru tokens. Otherwise a
+        // passthru flag that takes a value (e.g. `--some-flag`) could swallow
+        // "OH" as its value before Synthea sees it as the state. (A-9)
         if (!string.IsNullOrWhiteSpace(o.State)) argList.Add(o.State);
         if (!string.IsNullOrWhiteSpace(o.City)) argList.Add(o.City);
         if (!string.IsNullOrWhiteSpace(o.Zip)) argList.Add(o.Zip);
+        argList.AddRange(o.Passthru);
 
         return argList;
     }

--- a/tests/Synthea.Cli.UnitTests/ProgramRefactorTests.cs
+++ b/tests/Synthea.Cli.UnitTests/ProgramRefactorTests.cs
@@ -59,6 +59,13 @@ public class ProgramRefactorTests
             Passthru: new[] { "--extra" });
 
         var list = RunCommand.BuildArgumentList(args);
+        // Positional state/city/zip must come BEFORE passthru tokens so a
+        // passthru value-flag can't consume the state code as its value. (A-9)
+        var stateIdx = list.IndexOf("OH");
+        var passthruIdx = list.IndexOf("--extra");
+        Assert.True(stateIdx >= 0, "expected --state to appear in arg list");
+        Assert.True(passthruIdx >= 0, "expected passthru token to appear in arg list");
+        Assert.True(stateIdx < passthruIdx, $"state idx {stateIdx} should precede passthru idx {passthruIdx}");
         Assert.Contains("-p", list);
         Assert.Contains("5", list);
         Assert.Contains("-s", list);
@@ -79,6 +86,41 @@ public class ProgramRefactorTests
         Assert.Contains("Cleveland", list);
         Assert.Contains("44101", list);
         Assert.Contains("--extra", list);
+    }
+
+    [Fact]
+    public void Passthru_DoesNotSwallowPositionalState()
+    {
+        // A passthru value-flag like `--some-flag OH` would, in the old
+        // ordering, see "OH" emitted adjacent to the flag and consume it.
+        // The fix is structural: emit state/city/zip first, passthru last.
+        var args = new SyntheaArgs(
+            State: "OH",
+            City: null,
+            Gender: null,
+            AgeRange: null,
+            ModuleDir: null,
+            Modules: null,
+            Population: null,
+            Seed: null,
+            Config: null,
+            Zip: null,
+            FhirVersion: null,
+            InitialSnapshot: null,
+            UpdatedSnapshot: null,
+            DaysForward: null,
+            Formats: System.Array.Empty<string>(),
+            Passthru: new[] { "--some-flag" });
+
+        var list = RunCommand.BuildArgumentList(args);
+        var stateIdx = list.IndexOf("OH");
+        var flagIdx = list.IndexOf("--some-flag");
+        Assert.True(stateIdx >= 0);
+        Assert.True(flagIdx >= 0);
+        Assert.True(stateIdx < flagIdx,
+            $"state position must precede passthru flag; got state={stateIdx} flag={flagIdx}");
+        // And state must not appear adjacent-after the flag.
+        Assert.NotEqual(flagIdx + 1, stateIdx);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Reorders `BuildArgumentList`: positional state/city/zip now precede passthru tokens. Without this, a passthru flag that takes a value could consume the state code before Synthea sees it.
- Adds `Passthru_DoesNotSwallowPositionalState` regression test and an ordering assertion to `BuildArgumentList_BuildsExpectedFlags`.

Design decision (resolved pre-instantiation): **reorder only — no `--` separator required.**

Closes A-9.

## Test plan
- [x] 39 unit tests pass (one added)
- [x] Coverage gate passes (85.38% line / 80.31% branch)
- [x] `dotnet format` clean
- [ ] CI green on both legs
- [ ] master CI green after merge