### PR TITLE
feat(run): --add-format for additive output formats (A-8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The tool downloads the latest Synthea JAR on first use, caches it locally, and g
 | **Zero-install JAR** | Automatically fetches the newest `synthea-with-dependencies.jar` from GitHub releases and verifies its SHA-256 checksum when the upstream publishes one. |
 | **Configurable cache** | Stores the JAR under `%LOCALAPPDATA%\Synthea.Cli` on Windows and `~/.local/share/Synthea.Cli` on Linux/macOS; refresh anytime with `--refresh`. |
 | **Friendly flags** | `--state OH`, `--city "Columbus"`, `--output ./data`, `--seed 42`, `--initial-snapshot snap.json`, `--format FHIR` map directly to Synthea flags. |
+| **Additive formats** | `--format` is exclusive (enables only the named formats, disables the rest). Use `--add-format` (repeatable) to enable a format additively without overriding Synthea defaults. |
 | **Portable** | Runs on Windows, macOS, Linux—wherever .NET 8 + Java 11+ are available. |
 | **Unit-tested** | Complete test coverage via xUnit and Coverlet; network & process calls are fully mocked. |
 
@@ -64,6 +65,9 @@ synthea --refresh run -o ./output --population 10 --state TX --city Austin
 
 # Advance 30 days from an initial snapshot and limit to CSV output only
 synthea run -o ./output --initial-snapshot snap.json --days-forward 30 --format CSV
+
+# Keep Synthea's default exporters AND also turn on CCDA (additive)
+synthea run -o ./output --population 10 --state OH --add-format CCDA
 
 # Print the java invocation that would be run, without running it
 synthea run -o ./output --population 5 --state OH --print-args

--- a/src/Synthea.Cli/RunCommand.cs
+++ b/src/Synthea.Cli/RunCommand.cs
@@ -44,6 +44,7 @@ internal static class RunCommand
         var updatedSnapOpt = CreateUpdatedSnapshotOption();
         var daysForwardOpt = CreateDaysForwardOption();
         var formatOpt = CreateFormatOption();
+        var addFormatOpt = CreateAddFormatOption();
         var printArgsOpt = new Option<bool>("--print-args")
         {
             Description = "Print the java command line that would be run, then exit without running it. " +
@@ -67,6 +68,7 @@ internal static class RunCommand
         runCmd.Options.Add(updatedSnapOpt);
         runCmd.Options.Add(daysForwardOpt);
         runCmd.Options.Add(formatOpt);
+        runCmd.Options.Add(addFormatOpt);
         runCmd.Options.Add(printArgsOpt);
         runCmd.Arguments.Add(passthru);
 
@@ -76,7 +78,7 @@ internal static class RunCommand
         {
             var (hosting, args) = ParseRunOptions(parseResult, refreshOpt, javaOpt, outputOpt, stateOpt, cityOpt,
                 genderOpt, ageOpt, moduleDirOpt, moduleOpt, popOpt, seedOpt, configOpt, zipOpt,
-                fhirVerOpt, initialSnapOpt, updatedSnapOpt, daysForwardOpt, formatOpt, passthru);
+                fhirVerOpt, initialSnapOpt, updatedSnapOpt, daysForwardOpt, formatOpt, addFormatOpt, passthru);
             var printArgs = parseResult.GetValue(printArgsOpt);
 
             if (!string.IsNullOrWhiteSpace(args.City) && string.IsNullOrWhiteSpace(args.State))
@@ -216,23 +218,34 @@ internal static class RunCommand
         {
             argList.Add("--exporter.fhir.version=" + o.FhirVersion!.ToUpperInvariant());
         }
+        var formatPropertyMap = new Dictionary<string, string>
+        {
+            ["fhir"] = "exporter.fhir.export",
+            ["csv"] = "exporter.csv.export",
+            ["ccda"] = "exporter.ccda.export",
+            ["bulkfhir"] = "exporter.fhir.bulk_data",
+            ["bulk-fhir"] = "exporter.fhir.bulk_data",
+            ["cpcds"] = "exporter.cpcds.export"
+        };
         if (o.Formats.Length > 0)
         {
+            // Exclusive: enable named formats, disable everything else.
             var set = new HashSet<string>(o.Formats.Select(f => f.ToLowerInvariant()));
-            var map = new Dictionary<string, string>
+            foreach (var kv in formatPropertyMap)
             {
-                ["fhir"] = "exporter.fhir.export",
-                ["csv"] = "exporter.csv.export",
-                ["ccda"] = "exporter.ccda.export",
-                ["bulkfhir"] = "exporter.fhir.bulk_data",
-                ["cpcds"] = "exporter.cpcds.export"
-            };
-            foreach (var kv in map)
-            {
+                if (kv.Key == "bulk-fhir") continue; // alias; emitted via bulkfhir entry
                 var enable = set.Contains(kv.Key) ||
                              (kv.Key == "bulkfhir" && (set.Contains("bulk-fhir") || set.Contains("bulkfhir")));
                 argList.Add("--" + kv.Value + "=" + (enable ? "true" : "false"));
             }
+        }
+        foreach (var f in o.AdditionalFormats)
+        {
+            // Additive: enable each named format without disabling anything else.
+            // Synthea evaluates --exporter.X.export=true|false in order, so an
+            // additive "=true" after an exclusive "=false" wins.
+            if (formatPropertyMap.TryGetValue(f.ToLowerInvariant(), out var prop))
+                argList.Add("--" + prop + "=true");
         }
         // Positional state/city/zip must precede passthru tokens. Otherwise a
         // passthru flag that takes a value (e.g. `--some-flag`) could swallow
@@ -307,6 +320,7 @@ internal static class RunCommand
         Option<FileInfo?> updSnapOpt,
         Option<int?> daysOpt,
         Option<string[]> formatOpt,
+        Option<string[]> addFormatOpt,
         Argument<string[]> passthru)
     {
         var javaPathArg = parseResult.GetValue(javaOpt);
@@ -330,6 +344,7 @@ internal static class RunCommand
             UpdatedSnapshot: parseResult.GetValue(updSnapOpt),
             DaysForward: parseResult.GetValue(daysOpt),
             Formats: parseResult.GetValue(formatOpt) ?? Array.Empty<string>(),
+            AdditionalFormats: parseResult.GetValue(addFormatOpt) ?? Array.Empty<string>(),
             Passthru: parseResult.GetValue(passthru) ?? Array.Empty<string>());
         return (hosting, args);
     }
@@ -507,7 +522,22 @@ internal static class RunCommand
     {
         var opt = new Option<string[]>("--format")
         {
-            Description = "Output formats to generate (FHIR, CSV, CCDA, BULKFHIR, CPCDS)",
+            Description = "Output formats to generate (FHIR, CSV, CCDA, BULKFHIR, CPCDS). " +
+                          "Exclusive: enables only the named formats and disables all others. " +
+                          "Use --add-format to extend Synthea defaults instead.",
+            Arity = ArgumentArity.ZeroOrMore
+        };
+        opt.Validators.Add(MultiTokenValidator(v =>
+            AllowedFormats.Contains(v) ? null : $"Unsupported format '{v}'."));
+        return opt;
+    }
+
+    private static Option<string[]> CreateAddFormatOption()
+    {
+        var opt = new Option<string[]>("--add-format")
+        {
+            Description = "Additive format to enable in addition to Synthea defaults (FHIR, CSV, CCDA, BULKFHIR, CPCDS). " +
+                          "Repeatable. Does not disable any other format; see --format for exclusive semantics.",
             Arity = ArgumentArity.ZeroOrMore
         };
         opt.Validators.Add(MultiTokenValidator(v =>

--- a/src/Synthea.Cli/SyntheaArgs.cs
+++ b/src/Synthea.Cli/SyntheaArgs.cs
@@ -19,4 +19,5 @@ internal record SyntheaArgs(
     FileInfo? UpdatedSnapshot,
     int? DaysForward,
     string[] Formats,
+    string[] AdditionalFormats,
     string[] Passthru);

--- a/tests/Synthea.Cli.UnitTests/ProgramRefactorTests.cs
+++ b/tests/Synthea.Cli.UnitTests/ProgramRefactorTests.cs
@@ -56,6 +56,7 @@ public class ProgramRefactorTests
             UpdatedSnapshot: null,
             DaysForward: null,
             Formats: new[] { "fhir" },
+            AdditionalFormats: System.Array.Empty<string>(),
             Passthru: new[] { "--extra" });
 
         var list = RunCommand.BuildArgumentList(args);
@@ -89,6 +90,51 @@ public class ProgramRefactorTests
     }
 
     [Fact]
+    public void BuildArgumentList_FormatPlusAddFormat_EmitsBoth()
+    {
+        // Exclusive --format CSV disables all other formats. --add-format CCDA
+        // then re-enables CCDA additively. Synthea reads the args in order,
+        // so the later =true wins. (A-8)
+        var args = new SyntheaArgs(
+            State: null, City: null, Gender: null, AgeRange: null,
+            ModuleDir: null, Modules: null, Population: null, Seed: null,
+            Config: null, Zip: null, FhirVersion: null,
+            InitialSnapshot: null, UpdatedSnapshot: null, DaysForward: null,
+            Formats: new[] { "csv" },
+            AdditionalFormats: new[] { "ccda" },
+            Passthru: System.Array.Empty<string>());
+
+        var list = RunCommand.BuildArgumentList(args);
+        Assert.Contains("--exporter.csv.export=true", list);
+        // Exclusive run sets ccda=false first; additive must come *after*.
+        var ccdaFalseIdx = list.IndexOf("--exporter.ccda.export=false");
+        var ccdaTrueIdx = list.IndexOf("--exporter.ccda.export=true");
+        Assert.True(ccdaFalseIdx >= 0, "exclusive should emit ccda=false");
+        Assert.True(ccdaTrueIdx >= 0, "additive should emit ccda=true");
+        Assert.True(ccdaFalseIdx < ccdaTrueIdx,
+            $"additive ccda=true ({ccdaTrueIdx}) must follow exclusive ccda=false ({ccdaFalseIdx}) so Synthea picks =true.");
+    }
+
+    [Fact]
+    public void BuildArgumentList_AddFormatAlone_IsAdditiveOnly()
+    {
+        // Without --format, --add-format must only enable the named format —
+        // not emit any =false entries for the others.
+        var args = new SyntheaArgs(
+            State: null, City: null, Gender: null, AgeRange: null,
+            ModuleDir: null, Modules: null, Population: null, Seed: null,
+            Config: null, Zip: null, FhirVersion: null,
+            InitialSnapshot: null, UpdatedSnapshot: null, DaysForward: null,
+            Formats: System.Array.Empty<string>(),
+            AdditionalFormats: new[] { "csv" },
+            Passthru: System.Array.Empty<string>());
+
+        var list = RunCommand.BuildArgumentList(args);
+        Assert.Contains("--exporter.csv.export=true", list);
+        Assert.DoesNotContain(list, s => s.EndsWith("=false"));
+    }
+
+    [Fact]
     public void Passthru_DoesNotSwallowPositionalState()
     {
         // A passthru value-flag like `--some-flag OH` would, in the old
@@ -110,6 +156,7 @@ public class ProgramRefactorTests
             UpdatedSnapshot: null,
             DaysForward: null,
             Formats: System.Array.Empty<string>(),
+            AdditionalFormats: System.Array.Empty<string>(),
             Passthru: new[] { "--some-flag" });
 
         var list = RunCommand.BuildArgumentList(args);
@@ -147,6 +194,7 @@ public class ProgramRefactorTests
             UpdatedSnapshot: null,
             DaysForward: null,
             Formats: System.Array.Empty<string>(),
+            AdditionalFormats: System.Array.Empty<string>(),
             Passthru: System.Array.Empty<string>());
 
         var jar = new FileInfo(Path.Combine(tmpDir, "synthea.jar"));


### PR DESCRIPTION
## Summary
- Adds `--add-format <format>` (repeatable) to `run`. Validates against the same set as `--format` (FHIR / CSV / CCDA / BULKFHIR / CPCDS).
- `--format` keeps exclusive semantics (enables only named, disables rest). `--add-format` is additive — emitted *after* the exclusive block so Synthea's last-wins property parser sees the `=true` override.
- README features table gains an "Additive formats" row and a Quick Start example.

Design decision (resolved pre-instantiation): **keep exclusive `--format`; add `--add-format` for additive. No breaking change.**

Closes A-8.

## Test plan
- [x] 41 unit tests pass (2 added)
- [x] Coverage gate passes (85.97% line / 79.79% branch)
- [x] `dotnet format` clean
- [ ] CI green on both legs
- [ ] master CI green after merge