### PR TITLE
docs: architecture rewrite + ADR seed (A-16)

### DIFF
--- a/docs/adr/0001-static-seams-and-removal.md
+++ b/docs/adr/0001-static-seams-and-removal.md
@@ -1,0 +1,41 @@
+# 0001. Static seams and their removal
+
+## Status
+Accepted — implemented in `2eb5f5e` (PR #60).
+
+## Context
+Early iterations of `Synthea.Cli` used mutable-static seams to make
+production code testable without a DI container:
+
+- `Program.Runner` (settable `IProcessRunner` static)
+- `Program.EnsureJarAsyncFunc` (settable `Func<...>` static)
+- `JarManager.Http` (settable `HttpClient` static)
+- `JarManager.CacheRootOverride` (settable cache path static)
+
+Tests reassigned these fields per `[Fact]`. The pattern worked for
+single-threaded test execution but forced
+`[CollectionBehavior(DisableTestParallelization = true)]` in
+`AssemblyInfo.cs`. As the test suite grew, that ceiling started to
+hurt: every static mutation became a synchronization point, and any
+test that forgot to restore a field could poison the next one.
+
+## Decision
+Adopt `Microsoft.Extensions.DependencyInjection`. Wire:
+
+- `IProcessRunner` → `DefaultProcessRunner` (singleton)
+- `IJarSource` → `JarManager` (singleton; instance fields for the
+  `HttpClient`, cache root, and `ILogger<JarManager>`)
+
+`Program.Main` builds a default `ServiceProvider`; tests build their
+own and pass it to `Program.RunAsync(args, services)`. The four static
+seams disappear. `DisableTestParallelization` is removed; xunit runs
+the suite in parallel.
+
+## Consequences
+- Tests run in parallel; the unit suite stays under one second.
+- No global mutable state to forget to reset.
+- One new package (`Microsoft.Extensions.DependencyInjection`); ~2 KB
+  per published binary.
+- New parallelism exposed latent races that the serial suite hid
+  (process-wide `Environment.*` mutation in `CliConfigTests` — fixed
+  by `envGetter`-delegate overloads in PR #63).

--- a/docs/adr/0002-jar-caching-strategy.md
+++ b/docs/adr/0002-jar-caching-strategy.md
@@ -1,0 +1,38 @@
+# 0002. JAR caching strategy
+
+## Status
+Accepted — `cache list` / `cache clear` surfaced in `3905e40` (PR #63).
+
+## Context
+The Synthea JAR is ~50 MB. Re-downloading on every run is unfriendly to
+GitHub's anonymous rate limit (60 req/hour) and slows iteration. We
+need a cache with three properties:
+
+1. Survives across invocations and across reboots.
+2. Discoverable by users without grepping source.
+3. Inspectable and clearable without resorting to a file manager.
+
+## Decision
+- Store cached JARs under
+  `Environment.GetFolderPath(SpecialFolder.LocalApplicationData)/Synthea.Cli`.
+  On Windows this resolves to `%LOCALAPPDATA%\Synthea.Cli`; on Linux
+  and macOS the .NET runtime returns `~/.local/share/Synthea.Cli`. We
+  rejected `XDG_CACHE_HOME` (`~/.cache/...`) — an earlier README
+  claimed it, but the implementation never honoured it. Aligning the
+  README to the implementation rather than the other way around keeps
+  the cache path stable for existing users.
+- `JarManager.TryFindCachedJar()` returns the newest `*with-dependencies.jar`
+  in the cache directory without any network call.
+- The cache directory path is exposed via `IJarSource.CachePath` so
+  `synthea cache list` and `synthea cache clear` can operate on it
+  without duplicating the path-resolution logic.
+- `--jar` / `SYNTHEA_CLI_JAR_PATH` / `config.json.jarPath` bypasses the
+  cache entirely (A-5).
+
+## Consequences
+- One JAR file per release version stays on disk until the user runs
+  `synthea cache clear`. We do not auto-evict on age or size.
+- Multi-user machines see one cache per user profile, matching the
+  per-user `dotnet tool install` model.
+- The cache path is not configurable via flag — `--jar` is the escape
+  hatch for non-default locations.

--- a/docs/adr/0003-system-commandline-ga.md
+++ b/docs/adr/0003-system-commandline-ga.md
@@ -1,0 +1,38 @@
+# 0003. System.CommandLine GA migration
+
+## Status
+Accepted — migrated in `0965880` (PR #53).
+
+## Context
+`Synthea.Cli` shipped with `System.CommandLine` 2.0.0-beta4 — a beta
+package with a 9-figure download count but no GA backing. Dependabot
+opened a PR weekly to bump it to a newer beta or release candidate,
+each of which broke the API in non-trivial ways:
+
+- `InvocationContext` was removed in favour of `ParseResult`.
+- `SetHandler` overloads were reshaped.
+- `GetValueForOption` moved to `ParseResult.GetValue`.
+- `IsRequired = true` became `Required = true` on `Option<T>`.
+- The validator delegate changed from a named
+  `ValidateSymbolResult<OptionResult>` type to `Action<OptionResult>`.
+
+The validator delegate change was particularly nasty: a relapse to the
+beta-style `ValidateSymbolResult<OptionResult>` signature is a compile
+error in GA but the migration churn between betas made the error
+message ambiguous.
+
+## Decision
+Migrate straight to the first GA release (2.0.x) on a clean tree
+before any other work. Pin the version. Drop the `System.CommandLine`
+ignore-entry from `.github/dependabot.yml`. Add a regression test
+(`RunCommand_Validators_UseActionOptionResultDelegate`) that asserts
+each validator's delegate type, with a sanity check that the named
+beta-era `ValidateSymbolResult<T>` type is not loadable.
+
+## Consequences
+- No more weekly Dependabot reopens on the same package.
+- API surface is stable; future bumps are point releases.
+- Future contributors looking at the parser see GA documentation, not
+  beta blog posts.
+- One-time cost: rewrote every option definition and the handler
+  signature.

--- a/docs/adr/0004-format-semantics.md
+++ b/docs/adr/0004-format-semantics.md
@@ -1,0 +1,40 @@
+# 0004. `--format` semantics: exclusive plus `--add-format`
+
+## Status
+Accepted — `--add-format` added in `218838b` (PR #59).
+
+## Context
+`synthea run --format CSV` had a surprising side effect: it didn't
+*add* CSV to Synthea's default exporters; it *exclusively* enabled CSV
+and disabled every other format. A user reading the flag name
+expected the opposite. Two clean fixes:
+
+1. Flip `--format` to be additive, add a new `--only-format` (or
+   `--format-only`) for the exclusive behavior, and document a
+   migration window.
+2. Keep `--format` exclusive (existing behavior), add a new
+   `--add-format` (repeatable) for additive behavior, and document
+   loudly that `--format` excludes.
+
+Option 1 is "morally right" but breaks every existing script and CI
+pipeline that already learned the exclusive behavior. Option 2 keeps
+existing scripts working.
+
+## Decision
+**Option 2.** Keep `--format` exclusive. Add `--add-format` as a
+repeatable additive switch. README features table and Quick Start
+examples document the distinction.
+
+The `BuildArgumentList` emission order matters: exclusive `--format`
+emits `--exporter.X.export=true|false` for every known exporter
+*first*, then `--add-format` entries emit a follow-up `=true` per
+named format. Synthea reads command-line arguments left-to-right; the
+later `=true` wins. This means `--format CSV --add-format JSON` does
+the natural thing: only CSV and JSON exporters run.
+
+## Consequences
+- No breaking change. All existing scripts work as-is.
+- The flag pair is asymmetric and needs documentation. The README
+  features table calls this out.
+- A future redesign could deprecate `--format` and rename it
+  `--only-format`; deferred until/unless a real user asks for it.

--- a/docs/adr/0005-passthru-token-ordering.md
+++ b/docs/adr/0005-passthru-token-ordering.md
@@ -1,0 +1,55 @@
+# 0005. Passthru token ordering
+
+## Status
+Accepted — reordering shipped in `eb95460` (PR #58).
+
+## Context
+`synthea run` accepts arbitrary trailing tokens and forwards them to
+Synthea unchanged (the passthru argument). The historical
+`BuildArgumentList` emission order was:
+
+```
+[option-derived flags] + [passthru tokens] + [state] + [city] + [zip]
+```
+
+This is unsafe whenever a passthru token is itself a flag that takes
+a value. Consider:
+
+```
+synthea run --output ./out --state OH -- --some-synthea-flag
+```
+
+The historical order produced `... --some-synthea-flag OH` — Synthea,
+not knowing that `OH` was meant as the positional state, would
+consume it as the value of `--some-synthea-flag`. Subtle, silent, hard
+to debug.
+
+Two possible fixes:
+
+1. Require `--` as a separator before any passthru tokens, validate it,
+   and reject when missing.
+2. Move state/city/zip *before* the passthru tokens so they can't be
+   captured as a flag value.
+
+Option 1 is more explicit but breaks every existing invocation that
+didn't use `--`. Option 2 is purely structural and has no user-visible
+flag change.
+
+## Decision
+**Option 2.** Emit in this order:
+
+```
+[option-derived flags] + [state] + [city] + [zip] + [passthru tokens]
+```
+
+A passthru flag with a value still works — it just can't accidentally
+consume the positional codes. A regression test
+(`Passthru_DoesNotSwallowPositionalState`) pins the order.
+
+## Consequences
+- No user-visible flag change. No CI / script churn.
+- Synthea sees positional codes in the same lexical position as before
+  (top of arg list before passthru), so all existing invocations
+  behave identically.
+- Future passthru-related changes have a structural invariant to
+  preserve: positional codes precede passthru.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,34 @@
+# Architecture Decision Records
+
+This directory captures the major design decisions in `Synthea.Cli`.
+Each ADR is a short markdown file in the Michael Nygard template
+(Context / Decision / Status / Consequences). New decisions go in a
+numbered file; superseded ADRs stay in place with their status updated.
+
+## Index
+
+| # | Title | Status | Finding |
+|---|-------|--------|---------|
+| 0001 | [Static seams and their removal](0001-static-seams-and-removal.md) | Accepted | A-12 |
+| 0002 | [JAR caching strategy](0002-jar-caching-strategy.md) | Accepted | A-14 |
+| 0003 | [System.CommandLine GA migration](0003-system-commandline-ga.md) | Accepted | A-15 |
+| 0004 | [`--format` semantics](0004-format-semantics.md) | Accepted | A-8 |
+| 0005 | [Passthru token ordering](0005-passthru-token-ordering.md) | Accepted | A-9 |
+
+## Template
+
+```markdown
+# NNNN. Short title
+
+## Status
+Accepted | Proposed | Superseded by NNNN
+
+## Context
+What forces are at play? What problem is the decision addressing?
+
+## Decision
+What did we decide?
+
+## Consequences
+What gets easier? What gets harder? What does this lock in?
+```

--- a/docs/deliverables/Architecture.md
+++ b/docs/deliverables/Architecture.md
@@ -1,26 +1,218 @@
-# Architecture
+# Synthea.Cli Architecture
 
-This repository contains a small .NET command-line wrapper around the official Synthea JAR. The CLI downloads the JAR on demand and launches it with user-provided options. The actual Synthea project is maintained separately by MITRE.
+> A C4-style view of `Synthea.Cli`: a .NET 8 global tool that wraps the
+> MITRE Synthea synthetic-patient generator, handling JAR download,
+> caching, and process orchestration so users only need .NET and Java
+> installed.
 
-## synthea-cli program
+---
+
+## 1. Context (C4 Level 1)
+
+`Synthea.Cli` sits between a human (or CI agent) and the Synthea project's
+release JAR. It does not implement any synthetic-patient logic itself.
 
 ```mermaid
-flowchart TD
-    A([User]) --> B(Program.cs)
-    B --> C{Jar cached?}
-    C -- yes --> D[Run Java with JAR]
-    C -- no --> E[JarManager downloads JAR]
-    E --> D
-    D --> F[Synthea JAR executes]
+flowchart LR
+    User([User / CI])
+    SyntheaCli[Synthea.Cli<br/>.NET 8 global tool]
+    GitHub[(GitHub Releases<br/>synthetichealth/synthea)]
+    Java[Java JRE 11+]
+    Output[(Local filesystem<br/>output directory)]
+
+    User -->|run / cache list / cache clear| SyntheaCli
+    SyntheaCli -->|GET /releases/latest| GitHub
+    SyntheaCli -->|spawn java -jar synthea.jar ...| Java
+    Java -->|FHIR/CSV/CCDA/... files| Output
 ```
 
-`Program.cs` defines the command-line interface and orchestrates fetching the JAR via `JarManager`. `JarManager` checks a cache directory under the user's profile, hitting GitHub releases if necessary and verifying checksums. Once the JAR is ensured, `Program.cs` spawns a Java process and streams the output back to the console.
+Boundary of responsibility:
 
-## Synthea overview
+| In scope (this tool) | Out of scope |
+|----------------------|--------------|
+| CLI argument parsing & validation | Patient-generation algorithms |
+| JAR download, caching, checksum | Synthea module authoring |
+| Process orchestration & exit codes | FHIR/CSV export logic |
+| Configuration (CLI / env / file) | Long-term storage of generated data |
 
-The Synthea JAR itself is not included here. At a high level, Synthea is a Java application that simulates patients through state-machine modules and exports synthetic health records.
+---
 
+## 2. Containers (C4 Level 2)
 
-The CLI simply launches this JAR with user-supplied arguments to control the simulation size, output location, and other options.
+A "container" here is a process or persistent store the tool relies on.
 
-[Download this file](./Architecture.md)
+```mermaid
+flowchart TB
+    subgraph Local
+        Cli[synthea.exe<br/>dotnet tool]
+        Cache[(JAR cache<br/>%LOCALAPPDATA%\Synthea.Cli<br/>~/.local/share/Synthea.Cli)]
+        Config[(~/.synthea-cli/config.json)]
+        Out[(./output/...)]
+        Java[Java JRE 11+]
+    end
+    GitHub[(GitHub Releases API)]
+
+    Cli -- read --> Config
+    Cli <-- read/write --> Cache
+    Cli -- HTTPS --> GitHub
+    Cli -- spawn --> Java
+    Java -- write --> Out
+```
+
+| Container | Why |
+|-----------|-----|
+| `synthea` CLI process | The tool itself; short-lived, one invocation per run |
+| JAR cache directory | Avoids re-downloading on every run; survives across invocations |
+| Java JRE | Hosts the actual Synthea simulation; user-provided |
+| Config file | Persistent settings (token, proxy, default JAR path) |
+| Output directory | User-controlled; the tool only ensures it exists |
+
+---
+
+## 3. Components (C4 Level 3)
+
+Inside the `synthea` process:
+
+```mermaid
+flowchart TB
+    Program[Program<br/>composition root + DI]
+    Run[RunCommand]
+    Cache[CacheCommand]
+    Conf[CliConfig]
+    Jar[JarManager : IJarSource]
+    Proc[DefaultProcessRunner : IProcessRunner]
+    Log[ILoggerFactory<br/>console provider]
+    Http[HttpClient<br/>with optional proxy]
+
+    Program --> Run
+    Program --> Cache
+    Program --> Jar
+    Program --> Proc
+    Program --> Log
+    Program --> Http
+    Run --> Conf
+    Run --> Jar
+    Run --> Proc
+    Cache --> Jar
+    Jar --> Http
+    Jar --> Log
+```
+
+| Component | Responsibility |
+|-----------|----------------|
+| `Program` | Composition root. Builds `ServiceProvider`, parses verbosity flags, dispatches root command. |
+| `RunCommand` | `synthea run …` — option definitions, validators, `JarOverrides` resolution, process spawn. |
+| `CacheCommand` | `synthea cache list / clear`. Reads `IJarSource.CachePath` and operates on the directory. |
+| `CliConfig` | Loads `~/.synthea-cli/config.json`; provides CLI > env > config > default precedence helpers. |
+| `JarManager` (`IJarSource`) | Locates/downloads/verifies the Synthea JAR; per-request `Authorization` header when a token is configured. |
+| `DefaultProcessRunner` (`IProcessRunner`) | Wraps `System.Diagnostics.Process` behind an interface so tests can stub. |
+| `ILoggerFactory` | `Microsoft.Extensions.Logging` console provider; level driven by `--verbose` / `--quiet`. |
+| `HttpClient` | Built once at startup with `HTTPS_PROXY` / `HTTP_PROXY` honoured via `WebProxy`. |
+
+---
+
+## 4. Data flow — a typical `synthea run` invocation
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User
+    participant Cli as Program/RunCommand
+    participant Conf as CliConfig
+    participant Jar as JarManager
+    participant GH as GitHub Releases
+    participant Java as Java -jar synthea.jar
+
+    User->>Cli: synthea run -o ./out --state OH -p 5
+    Cli->>Cli: Parse args, validate options
+    Cli->>Conf: Load ~/.synthea-cli/config.json
+    Cli->>Cli: ResolveJarOverrides (CLI > env > config > default)
+    alt --jar / SYNTHEA_CLI_JAR_PATH set
+        Cli->>Jar: EnsureJarAsync({JarPath = ...})
+        Jar-->>Cli: FileInfo (skip network)
+    else cached JAR present
+        Cli->>Jar: EnsureJarAsync()
+        Jar-->>Cli: FileInfo (cached)
+    else download required
+        Cli->>Jar: EnsureJarAsync()
+        Jar->>GH: GET /repos/synthetichealth/synthea/releases/latest
+        GH-->>Jar: release JSON
+        Jar->>GH: GET <jar asset>
+        Jar->>GH: GET <.sha256 asset> (if present)
+        Jar-->>Cli: FileInfo (newly cached)
+    end
+    Cli->>Java: spawn (working dir = output)
+    Java-->>User: stdout / stderr (relayed)
+    Java-->>User: FHIR/CSV/CCDA/... files in ./out
+```
+
+---
+
+## 5. Failure modes & exit codes
+
+| Exit | When | Where |
+|------|------|-------|
+| `0` | Success; Synthea's own exit code is propagated when the JAR ran | top-level handler |
+| `1` | Argument validation error (state code, ZIP, gender, age range, format, …) | `System.CommandLine` validators |
+| `2` | Filesystem / I/O error (`IOException`) | `RunCommand` try/catch |
+| `3` | External-dependency error: GitHub unreachable, checksum mismatch, missing release asset, `--insist-checksum` with no `.sha256` | `RunCommand` try/catch |
+| `4` | Unexpected `Exception` (catch-all) | `RunCommand` try/catch |
+| `130` | Cancelled by user (Ctrl+C); the child Java process is killed via `proc.Kill(entireProcessTree: true)` | cancellation registration |
+
+Operational notes:
+
+- The download progress line uses `\r` only when stdout is a TTY; redirected
+  output gets a single `Downloading Synthea JAR…` line so log files stay
+  greppable.
+- `Console.OutputEncoding` is forced to UTF-8 at `Main` entry so
+  diacritic patient names render correctly on Windows code pages.
+
+---
+
+## 6. Deployment topology
+
+`Synthea.Cli` is published as a [.NET global tool](https://learn.microsoft.com/dotnet/core/tools/global-tools):
+
+```bash
+dotnet tool install --global Synthea.Cli
+synthea --help
+```
+
+No system installer, no daemon, no admin rights. The tool drops itself
+into the user's per-user `~/.dotnet/tools` directory and is on PATH after
+the standard `dotnet tool` shim. Symbols package (`.snupkg`) is published
+alongside the nupkg for step-into debugging.
+
+Cross-platform: tested on Windows, macOS, Linux through the
+`ubuntu-latest` + `windows-latest` CI matrix.
+
+---
+
+## 7. Security posture
+
+- **`GITHUB_TOKEN`** (env or `~/.synthea-cli/config.json`) attaches as
+  `Authorization: Bearer <token>` to GitHub API and asset-download
+  requests. Sent per-request — not stored on `HttpClient.DefaultHeaders`
+  — so it does not leak to non-GitHub URLs if `JarManager` is reused.
+- **`HTTPS_PROXY` / `HTTP_PROXY`** are wired into `HttpClientHandler.Proxy`
+  at startup. `HttpClient` does not expose its handler for runtime
+  mutation, so per-call proxy overrides are not supported.
+- **Checksum verification** runs whenever the upstream release publishes
+  a `.sha256` asset. `--insist-checksum` (or
+  `SYNTHEA_CLI_INSIST_CHECKSUM=true`) fails the run if no checksum is
+  available; default off for backward compatibility, recommended on for
+  production CI.
+- **No credentials are logged.** Token and proxy values appear only in
+  request construction; the structured logger emits the request URL but
+  never the `Authorization` header.
+
+---
+
+## 8. Where to read next
+
+- [`docs/adr/`](../adr/) — Architecture Decision Records seeded for the
+  major decisions documented above.
+- [`SyntheaCli-notes.md`](../../SyntheaCli-notes.md) — running design
+  register; finding IDs (A-N) referenced throughout.
+- [`SyntheaCli-notes-design-review.md`](../../SyntheaCli-notes-design-review.md)
+  — original architectural review that drove the work.


### PR DESCRIPTION
## Summary
- **`docs/deliverables/Architecture.md`** rewritten from a 27-line stub to a full C4-style architecture document: context, container, and component views; sequence diagram of a typical `synthea run` invocation; failure modes / exit codes; deployment topology; security posture (token, proxy, checksum).
- **`docs/adr/`** seeded with five Michael-Nygard-format ADRs for the major decisions of the recent ralph run:

  | # | Decision | Finding | Commit |
  |---|----------|---------|--------|
  | 0001 | Static seams and their removal | A-12 | `2eb5f5e` |
  | 0002 | JAR caching strategy | A-14 | `3905e40` |
  | 0003 | System.CommandLine GA migration | A-15 | `0965880` |
  | 0004 | `--format` semantics (keep exclusive, add `--add-format`) | A-8 | `218838b` |
  | 0005 | Passthru token ordering | A-9 | `eb95460` |

- `docs/adr/README.md` is the index + Nygard template pointer.

## Gate evidence
- Docs-only PR. **No source changes**; build / tests / `dotnet format` unchanged.
- Coverage gate: **N/A** (no code modified).
- Cited commit SHAs all exist on `master` (verified via `git cat-file -e`).
- Scope: 7 files, all in `docs/` — within Phase 12's declared scope.

Closes A-16. Reference: `SyntheaCli-notes.md` §8 A-16.