### PR TITLE
fix(run): --state accepts both USPS codes and full state names

### DIFF
--- a/src/Synthea.Cli/RunCommand.cs
+++ b/src/Synthea.Cli/RunCommand.cs
@@ -346,7 +346,7 @@ internal static class RunCommand
             JarPath: parseResult.GetValue(jarOpt),
             InsistChecksum: parseResult.GetValue(insistChecksumOpt));
         var args = new SyntheaArgs(
-            State: parseResult.GetValue(stateOpt),
+            State: UsStates.Normalize(parseResult.GetValue(stateOpt)),
             City: parseResult.GetValue(cityOpt),
             Gender: parseResult.GetValue(genderOpt),
             AgeRange: parseResult.GetValue(ageOpt),
@@ -413,16 +413,26 @@ internal static class RunCommand
 
     private static Option<string?> CreateStateOption()
     {
-        // Format-only check (two letters). The previous 50-entry US-state
-        // allowlist silently rejected DC, PR, GU, VI, and any future
-        // Synthea-supported geo codes. Defer the "is this a real place?"
-        // check to Synthea itself, which owns the geo data.
+        // Accept either a 2-letter USPS code (e.g. "OH") or a full state
+        // name (e.g. "Ohio", "New Hampshire"). 2-letter codes are
+        // converted to the full name in ParseRunOptions before passthru,
+        // because Synthea's geography data is keyed by full name and
+        // rejects bare 2-letter codes with "Unable to select a random
+        // city id."
         var opt = new Option<string?>("--state")
         {
-            Description = "Two-letter state/territory code (e.g. OH, TX, DC, PR). Format-only check; Synthea rejects unknown codes itself."
+            Description = "State name (e.g. 'Ohio') or two-letter USPS code (e.g. 'OH'). 2-letter codes are converted to the full name automatically. Synthea owns the place-existence check."
         };
         opt.Validators.Add(SingleTokenValidator(v =>
-            v.Length == 2 && v.All(char.IsLetter) ? null : "State code must be exactly two letters."));
+        {
+            if (v.Length == 2 && v.All(char.IsLetter))
+            {
+                return UsStates.IsKnownCode(v)
+                    ? null
+                    : $"Unknown 2-letter state code '{v.ToUpperInvariant()}'. Use a USPS code (e.g. OH, TX, DC) or the full name (e.g. Ohio).";
+            }
+            return v.Length >= 3 ? null : "State must be a 2-letter USPS code or the full state name.";
+        }));
         return opt;
     }
 

--- a/src/Synthea.Cli/UsStates.cs
+++ b/src/Synthea.Cli/UsStates.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+
+namespace Synthea.Cli;
+
+/// <summary>
+/// US-state lookup. Synthea's geography data is keyed by full state name
+/// ("Ohio"), not by two-letter code ("OH"), so the CLI converts 2-letter
+/// input to the full name before passthru. Full names are passed through
+/// unchanged; Synthea remains the source of truth for whether a given
+/// place exists in its dataset.
+/// </summary>
+internal static class UsStates
+{
+    /// <summary>
+    /// Maps two-letter USPS codes (uppercase) to the full state/territory
+    /// name that Synthea recognizes. Includes 50 states + DC + the five
+    /// inhabited territories.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<string, string> CodeToName = new Dictionary<string, string>
+    {
+        ["AL"] = "Alabama",
+        ["AK"] = "Alaska",
+        ["AZ"] = "Arizona",
+        ["AR"] = "Arkansas",
+        ["CA"] = "California",
+        ["CO"] = "Colorado",
+        ["CT"] = "Connecticut",
+        ["DE"] = "Delaware",
+        ["FL"] = "Florida",
+        ["GA"] = "Georgia",
+        ["HI"] = "Hawaii",
+        ["ID"] = "Idaho",
+        ["IL"] = "Illinois",
+        ["IN"] = "Indiana",
+        ["IA"] = "Iowa",
+        ["KS"] = "Kansas",
+        ["KY"] = "Kentucky",
+        ["LA"] = "Louisiana",
+        ["ME"] = "Maine",
+        ["MD"] = "Maryland",
+        ["MA"] = "Massachusetts",
+        ["MI"] = "Michigan",
+        ["MN"] = "Minnesota",
+        ["MS"] = "Mississippi",
+        ["MO"] = "Missouri",
+        ["MT"] = "Montana",
+        ["NE"] = "Nebraska",
+        ["NV"] = "Nevada",
+        ["NH"] = "New Hampshire",
+        ["NJ"] = "New Jersey",
+        ["NM"] = "New Mexico",
+        ["NY"] = "New York",
+        ["NC"] = "North Carolina",
+        ["ND"] = "North Dakota",
+        ["OH"] = "Ohio",
+        ["OK"] = "Oklahoma",
+        ["OR"] = "Oregon",
+        ["PA"] = "Pennsylvania",
+        ["RI"] = "Rhode Island",
+        ["SC"] = "South Carolina",
+        ["SD"] = "South Dakota",
+        ["TN"] = "Tennessee",
+        ["TX"] = "Texas",
+        ["UT"] = "Utah",
+        ["VT"] = "Vermont",
+        ["VA"] = "Virginia",
+        ["WA"] = "Washington",
+        ["WV"] = "West Virginia",
+        ["WI"] = "Wisconsin",
+        ["WY"] = "Wyoming",
+        ["DC"] = "District of Columbia",
+        ["PR"] = "Puerto Rico",
+        ["VI"] = "Virgin Islands",
+        ["GU"] = "Guam",
+        ["AS"] = "American Samoa",
+        ["MP"] = "Northern Mariana Islands",
+    };
+
+    /// <summary>
+    /// True if <paramref name="input"/> is a recognized 2-letter USPS code
+    /// (case insensitive). Use from the option validator to reject unknown
+    /// 2-letter values before they reach Synthea.
+    /// </summary>
+    public static bool IsKnownCode(string input)
+        => input.Length == 2 && CodeToName.ContainsKey(input.ToUpperInvariant());
+
+    /// <summary>
+    /// Converts user-supplied state input to the form Synthea expects.
+    /// 2-letter codes → full name (uppercased for lookup). Anything else
+    /// (full names, multi-word names) is returned unchanged so Synthea
+    /// can validate it. Returns null for null/empty input.
+    /// </summary>
+    public static string? Normalize(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input)) return null;
+        return input.Length == 2 && CodeToName.TryGetValue(input.ToUpperInvariant(), out var full)
+            ? full
+            : input;
+    }
+}

--- a/tests/Synthea.Cli.UnitTests/ProgramHandlerTests.cs
+++ b/tests/Synthea.Cli.UnitTests/ProgramHandlerTests.cs
@@ -41,14 +41,54 @@ public class ProgramHandlerTests : IDisposable
     public async Task BuildsProcessStartInfoWithStateAndCity()
     {
         var outDir = Path.Combine(_tempDir, "out1");
+        // 2-letter code on input; CLI normalizes to "Ohio" before passthru
+        // because Synthea's geography data is keyed by full state name.
         var code = await Run("run", "--output", outDir, "--state", "OH", "--city", "Cleveland");
         Assert.Equal(0, code);
 
         var psi = _runner.StartInfo!;
         Assert.Equal("java", psi.FileName);
         Assert.Equal(outDir, psi.WorkingDirectory);
-        Assert.Equal(new[] { "-jar", _jar.FullName, "OH", "Cleveland" }, psi.ArgumentList);
+        Assert.Equal(new[] { "-jar", _jar.FullName, "Ohio", "Cleveland" }, psi.ArgumentList);
         Assert.True(Directory.Exists(outDir));
+    }
+
+    [Fact]
+    public async Task StateFullName_PassesThroughUnchanged()
+    {
+        var outDir = Path.Combine(_tempDir, "out-state-fullname");
+        var code = await Run("run", "--output", outDir, "--state", "Massachusetts");
+        Assert.Equal(0, code);
+
+        Assert.Equal(new[] { "-jar", _jar.FullName, "Massachusetts" }, _runner.StartInfo!.ArgumentList);
+    }
+
+    [Fact]
+    public async Task StateMultiWordFullName_PassesThroughUnchanged()
+    {
+        var outDir = Path.Combine(_tempDir, "out-state-multiword");
+        var code = await Run("run", "--output", outDir, "--state", "New Hampshire");
+        Assert.Equal(0, code);
+
+        Assert.Equal(new[] { "-jar", _jar.FullName, "New Hampshire" }, _runner.StartInfo!.ArgumentList);
+    }
+
+    [Fact]
+    public async Task StateLowercaseCode_NormalizedToFullName()
+    {
+        var outDir = Path.Combine(_tempDir, "out-state-lower");
+        var code = await Run("run", "--output", outDir, "--state", "tx");
+        Assert.Equal(0, code);
+
+        Assert.Equal(new[] { "-jar", _jar.FullName, "Texas" }, _runner.StartInfo!.ArgumentList);
+    }
+
+    [Fact]
+    public async Task InvalidStateCodeReturnsError()
+    {
+        var outDir = Path.Combine(_tempDir, "out-state-bad");
+        var code = await Run("run", "--output", outDir, "--state", "ZZ");
+        Assert.NotEqual(0, code);
     }
 
     [Fact]
@@ -241,9 +281,10 @@ public class ProgramHandlerTests : IDisposable
     }
 
     [Theory]
-    [InlineData("X")]      // too short
-    [InlineData("XYZ")]    // too long
-    [InlineData("X1")]     // not all letters
+    [InlineData("X")]      // single letter — neither a 2-letter code nor a plausible state name
+    [InlineData("X1")]     // 2-char but not all letters
+    [InlineData("ZZ")]     // 2-letter shape but not a real USPS code
+    [InlineData("99")]     // 2-char digits — fails the 2-letter and the >=3 checks
     public async Task InvalidStateFormatReturnsError(string badState)
     {
         var outDir = Path.Combine(_tempDir, Path.GetRandomFileName());
@@ -286,10 +327,11 @@ public class ProgramHandlerTests : IDisposable
     public async Task ZipArgument_ValidZip()
     {
         var outDir = Path.Combine(_tempDir, "out23");
+        // OH normalizes to Ohio for the passthru (Synthea wants full names).
         var code = await Run("run", "--output", outDir, "--state", "OH", "--zip", "44101");
         Assert.Equal(0, code);
         var list = _runner.StartInfo!.ArgumentList;
-        Assert.Equal(new[] { "-jar", _jar.FullName, "OH", "44101" }, list);
+        Assert.Equal(new[] { "-jar", _jar.FullName, "Ohio", "44101" }, list);
     }
 
     [Fact]

--- a/tests/Synthea.Cli.UnitTests/UsStatesTests.cs
+++ b/tests/Synthea.Cli.UnitTests/UsStatesTests.cs
@@ -1,0 +1,68 @@
+using Synthea.Cli;
+using Xunit;
+
+namespace Synthea.Cli.UnitTests;
+
+public class UsStatesTests
+{
+    [Theory]
+    [InlineData("OH", "Ohio")]
+    [InlineData("oh", "Ohio")]
+    [InlineData("Oh", "Ohio")]
+    [InlineData("MA", "Massachusetts")]
+    [InlineData("DC", "District of Columbia")]
+    [InlineData("PR", "Puerto Rico")]
+    [InlineData("VI", "Virgin Islands")]
+    [InlineData("MP", "Northern Mariana Islands")]
+    public void Normalize_TwoLetterCode_ReturnsFullName(string input, string expected)
+    {
+        Assert.Equal(expected, UsStates.Normalize(input));
+    }
+
+    [Theory]
+    [InlineData("Ohio")]
+    [InlineData("Massachusetts")]
+    [InlineData("New Hampshire")]
+    [InlineData("Puerto Rico")]
+    public void Normalize_FullName_ReturnsUnchanged(string input)
+    {
+        Assert.Equal(input, UsStates.Normalize(input));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Normalize_NullOrEmpty_ReturnsNull(string? input)
+    {
+        Assert.Null(UsStates.Normalize(input));
+    }
+
+    [Fact]
+    public void Normalize_UnknownFullName_PassesThrough()
+    {
+        // Synthea owns the place-existence check; the CLI does not
+        // second-guess names of length >= 3.
+        Assert.Equal("Atlantis", UsStates.Normalize("Atlantis"));
+    }
+
+    [Theory]
+    [InlineData("OH", true)]
+    [InlineData("oh", true)]
+    [InlineData("MP", true)]
+    [InlineData("ZZ", false)]
+    [InlineData("XX", false)]
+    [InlineData("OHO", false)] // 3 letters — not a code
+    [InlineData("O", false)]   // 1 letter — not a code
+    public void IsKnownCode_ReturnsExpected(string input, bool expected)
+    {
+        Assert.Equal(expected, UsStates.IsKnownCode(input));
+    }
+
+    [Fact]
+    public void CodeToName_Has50StatesPlusDcPlusFiveTerritories()
+    {
+        // 50 states + DC + 5 territories (PR, VI, GU, AS, MP) = 56.
+        Assert.Equal(56, UsStates.CodeToName.Count);
+    }
+}


### PR DESCRIPTION
## Summary

The `--state` flag was broken in **both directions**:

- 2-letter USPS codes (`--state OH`) passed the CLI validator but caused Synthea to throw `java.lang.RuntimeException: Unable to select a random city id` — Synthea's geography data is keyed by full state name.
- Full state names (`--state Massachusetts`) were rejected by the CLI's `must be exactly two letters` validator before reaching Synthea.

Workarounds were to either omit `--state` (Synthea defaults to Massachusetts) or use raw passthru (`-- Massachusetts`). Both poor UX and undiscoverable.

## Fix (Option C)

- New `UsStates.cs` with a 56-entry lookup (50 states + DC + 5 inhabited territories) keyed by USPS code → full name.
- Validator accepts either a known 2-letter code (case insensitive) or any string of length ≥ 3.
- `ParseRunOptions` calls `UsStates.Normalize` to convert 2-letter codes to full names before passthru.
- Full names pass through unchanged so Synthea remains the source of truth for place-existence.

## Behavior matrix

| Input | Before | After |
|-------|--------|-------|
| `--state OH` | CLI accepts; Synthea throws `Unable to select a random city id` | `Ohio` → passes to Synthea |
| `--state oh` | CLI accepts; same Synthea failure | `Ohio` → passes (lowercase OK) |
| `--state Ohio` | CLI rejects: "must be exactly two letters" | `Ohio` → passes |
| `--state New Hampshire` | CLI rejects | `New Hampshire` → passes |
| `--state ZZ` | CLI accepts; Synthea throws | CLI rejects with "Unknown 2-letter state code 'ZZ'..." |
| `--state XYZ` | CLI rejects: "too long" | CLI accepts; Synthea decides (correct deferral) |

## Tests

- **New**: `UsStatesTests.cs` — `Normalize` + `IsKnownCode` + 56-entry guard.
- **Updated**: `ProgramHandlerTests.cs` — existing `BuildsProcessStartInfoWithStateAndCity` and `ZipArgument_ValidZip` now expect normalized `Ohio` instead of raw `OH`. New tests for full-name, multi-word, lowercase, and invalid-code paths. `InvalidStateFormatReturnsError` loses the `XYZ` case (now valid input from the CLI's perspective) and gains `ZZ` / `99`.

## Gates

- Build: clean (0 warnings, 0 errors)
- Tests: 104/104 passing
- Format: `dotnet format --verify-no-changes --severity warn` clean
- Coverage: **86.96% line / 82.84% branch** (above 80/75 gate; slightly improved from 85.97/79.79 baseline because `UsStates` is fully covered)

## Files in scope

- `src/Synthea.Cli/UsStates.cs` (new)
- `src/Synthea.Cli/RunCommand.cs` (validator + normalize call)
- `tests/Synthea.Cli.UnitTests/UsStatesTests.cs` (new)
- `tests/Synthea.Cli.UnitTests/ProgramHandlerTests.cs` (updated 2, added 4)

## Discovered

Live during the 2026-05-16 demo walkthrough on dev100 immediately after v0.3.0 install. Was tracked in `workspace-kmanl/TODO.md` under "SyntheaCli (NEW — 2026-05-16)" before this fix.

## Test plan

- [x] Run unit tests locally: `dotnet test --no-build --filter "Category!=Integration"` → 104/104
- [x] Verify coverage: `dotnet test ... --collect:"XPlat Code Coverage"` → 86.96/82.84
- [x] Verify format: `dotnet format --verify-no-changes --severity warn` → clean
- [ ] CI green on ubuntu-latest + windows-latest matrix
- [ ] Manual smoke on dev100 after merge: `synthea run -o C:\Temp\synthea-oh -p 2 --state OH` produces records with `Location: Ohio`