### PR TITLE
chore(net): upgrade to .NET 10 (LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
       - name: Restore dependencies
         run: dotnet restore
       - name: Verify formatting

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
       - name: Set version
         run: |
           if [ "$GITHUB_REF_TYPE" = "tag" ]; then

--- a/JavaTestApp/JavaTestApp.csproj
+++ b/JavaTestApp/JavaTestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Synthea.Cli/Synthea.Cli.csproj
+++ b/src/Synthea.Cli/Synthea.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>
@@ -24,9 +24,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
     <PackageReference Include="System.CommandLine" Version="2.0.8" />
   </ItemGroup>
 

--- a/tests/Synthea.Cli.IntegrationTests/Synthea.Cli.IntegrationTests.csproj
+++ b/tests/Synthea.Cli.IntegrationTests/Synthea.Cli.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/Synthea.Cli.UnitTests/Synthea.Cli.UnitTests.csproj
+++ b/tests/Synthea.Cli.UnitTests/Synthea.Cli.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
## Summary

Bumps SyntheaCli + tests + JavaTestApp from `net8.0` (LTS, ends Nov 2026) to **`net10.0`** (current LTS, ends Nov 2028). `Microsoft.Extensions.*` packages bumped from `8.0.1` to `10.0.8`. CI workflows bumped from `setup-dotnet 8.0.x` to `10.0.x`.

`System.CommandLine` stays at 2.0.8 (TFM-agnostic GA). xUnit / Coverlet / coverlet.msbuild unchanged.

## Files changed

| File | Change |
|------|--------|
| `src/Synthea.Cli/Synthea.Cli.csproj` | TFM + 3 `Microsoft.Extensions.*` versions |
| `tests/Synthea.Cli.UnitTests/Synthea.Cli.UnitTests.csproj` | TFM |
| `tests/Synthea.Cli.IntegrationTests/Synthea.Cli.IntegrationTests.csproj` | TFM |
| `JavaTestApp/JavaTestApp.csproj` | TFM (was net9.0 — bumped for consistency) |
| `.github/workflows/ci.yml` | setup-dotnet 8.0.x → 10.0.x |
| `.github/workflows/nuget.yml` | setup-dotnet 8.0.x → 10.0.x |
| `.github/workflows/codeql.yml` | setup-dotnet 8.0.x → 10.0.x |

Total diff: 7 files, +10/-10 lines.

## Risk profile

Genuinely low for this codebase:
- Pure CLI wrapper, no native interop, no AOT-sensitive reflection
- Stays in supported BCL surface
- No preview-API consumption
- Test coverage: 86.96% line / 82.84% branch (above 80/75 gate)
- Integration tests exercise real `java -jar synthea.jar` invocation, so any runtime delta in process/IO surface would surface here
- CI matrix (ubuntu + windows) catches platform-specific issues

## Local validation status

**Deferred.** dev100 has SDK 8.0.421 + 9.0.313 only; .NET 10 SDK install requires admin which we did not elevate. This PR's CI matrix is the validation gate. If any leg fails, will iterate.

## Test plan

- [ ] CI `build (ubuntu-latest)` green — proves net10 build + 104 unit tests pass on Linux
- [ ] CI `build (windows-latest)` green — same on Windows
- [ ] CI `CodeQL` green — proves analyzers handle net10 source
- [ ] Coverage report from CI stays ≥ 80/75
- [ ] Post-merge smoke on dev100: pack locally with `dotnet pack ... -p:PackageVersion=0.4.0-local`, install as global tool, run `synthea run -o ... -p 2 --state OH` end-to-end

## Follow-up if merged

Tag `v0.4.0` (minor bump for the runtime change) → `nuget.yml` publishes `synthea-cli` 0.4.0 to nuget.org.