### PR TITLE
docs(readme): rewrite use-case-first; refresh stale platform/version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,101 +1,184 @@
-# Synthea.Cli
+# synthea-cli
 
-[![NuGet](https://img.shields.io/nuget/v/Synthea.Cli.svg)](https://www.nuget.org/packages/Synthea.Cli/)
+[![NuGet](https://img.shields.io/nuget/v/synthea-cli.svg)](https://www.nuget.org/packages/synthea-cli/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-`Synthea.Cli` is a cross-platform **.NET 8** command-line wrapper around **[Synthea™](https://github.com/synthetichealth/synthea)** — MITRE’s open-source synthetic health-record generator.  
-The tool downloads the latest Synthea JAR on first use, caches it locally, and gives you a simple, typed interface plus first-class scripting and container support.
+**Generate realistic synthetic patient data on Windows, macOS, or Linux with a single command.** No HIPAA exposure, no Java setup, no JAR hunting — `synthea-cli` wraps MITRE's [Synthea™](https://github.com/synthetichealth/synthea) (the gold-standard synthetic health-record generator) as a `dotnet tool` you install once and forget about.
+
+```bash
+dotnet tool install --global synthea-cli
+synthea run -o ./output -p 100 --state OH --add-format CSV
+# 100 Ohio patients with realistic clinical histories in FHIR + CSV, 60 seconds.
+```
 
 ---
 
-## Table of Contents
+## Use it for
 
-- [Features](#features)
-- [Quick Start](#quick-start)
-  - [Prerequisites](#prerequisites)
-  - [Install as a global tool](#install-as-a-global-tool)
-  - [Run](#run)
-- [Developer Guide](#developer-guide)
-  - [Clone \& Build](#clone--build)
-  - [Unit Tests](#unit-tests)
-  - [Docker](#docker)
-  - [`setup.sh` for CI / Codex](#setupsh-for-ci--codex)
-    - [GitHub Actions example](#github-actions-example)
-  - [Running Integration Tests](#running-integration-tests)
-- [Project Layout](#project-layout)
-- [Contributing](#contributing)
-- [License \& Credits](#license--credits)
+- **Testing FHIR integrations** — generate patient bundles to POST against HAPI FHIR, Azure Health Data Services, Google Healthcare API, AWS HealthLake, or any FHIR R4/STU3 endpoint. Bulk-data NDJSON output supports `$import` workflows.
+- **Validating EMR / HL7 / CCDA pipelines** — generate realistic encounters, conditions, medications, immunizations, and procedures with SNOMED/LOINC/RxNorm codes. CCDA documents come out as XML; CSV exports map cleanly to OMOP CDM via [OHDSI ETL-Synthea](https://github.com/OHDSI/ETL-Synthea).
+- **Loading test data into clinical data warehouses** — CSV exporter splits patients/encounters/conditions/medications/etc. into separate files, with referential integrity. Use as the source data for dbt models, dimensional warehouses, and analytics pipelines.
+- **Stress-testing claims pipelines** — CPCDS exporter produces CARIN BB-shaped claims; BFD RIF exporter produces Medicare-shaped claims. Both with realistic adjudication patterns.
+- **Reproducible test fixtures** — `--seed` plus `--clinician-seed` plus `--single-person-seed` make any generation byte-for-byte reproducible across machines and CI runs.
+
+If you're a healthcare data engineer, integration tester, or anyone who needs realistic-but-fake patient data, this saves you the install dance.
+
+---
+
+## Table of contents
+
+- [Quick start](#quick-start)
+- [Common scenarios](#common-scenarios)
+- [Cache management](#cache-management)
+- [Configuration](#configuration)
+- [Exit codes](#exit-codes)
 - [Architecture](#architecture)
+- [Developer guide](#developer-guide)
+- [Contributing](#contributing)
+- [License & credits](#license--credits)
 
 ---
 
-## Features
-
-| Feature | Details |
-|---------|---------|
-| **Zero-install JAR** | Automatically fetches the newest `synthea-with-dependencies.jar` from GitHub releases and verifies its SHA-256 checksum when the upstream publishes one. |
-| **Configurable cache** | Stores the JAR under `%LOCALAPPDATA%\Synthea.Cli` on Windows and `~/.local/share/Synthea.Cli` on Linux/macOS; refresh anytime with `--refresh`. |
-| **Friendly flags** | `--state OH`, `--city "Columbus"`, `--output ./data`, `--seed 42`, `--initial-snapshot snap.json`, `--format FHIR` map directly to Synthea flags. |
-| **Additive formats** | `--format` is exclusive (enables only the named formats, disables the rest). Use `--add-format` (repeatable) to enable a format additively without overriding Synthea defaults. |
-| **Verbosity control** | `--verbose` enables debug logs; `--quiet` suppresses info logs (warnings and errors still print). Default is info-level via `Microsoft.Extensions.Logging`. |
-| **Portable** | Runs on Windows, macOS, Linux—wherever .NET 8 + Java 11+ are available. |
-| **Unit-tested** | Complete test coverage via xUnit and Coverlet; network & process calls are fully mocked. |
-
----
-
-## Quick Start
+## Quick start
 
 ### Prerequisites
 
-- **.NET 8 SDK** — <https://dotnet.microsoft.com/download>  
-- **Java ≥ 11** in your `PATH` (`java -version`) – *only required at runtime*.
+- **.NET 10 SDK** — <https://dotnet.microsoft.com/download> (LTS, ends Nov 2028)
+- **Java ≥ 17** in your `PATH` (verify with `java -version`) — required at runtime only. Synthea v4.0 dropped JDK 11 support; OpenJDK 17 LTS (Eclipse Temurin recommended) or newer is required.
 
 ### Install as a global tool
 
 ```bash
-dotnet tool install --global Synthea.Cli --version 1.0.0
-```
-
-### Run
-
-```bash
-# Generate 10 synthetic patients from Ohio into ./output using a fixed seed
-synthea run --output ./output --population 10 --state OH --seed 12345
-
-# Same, but force-refresh the cached JAR
-synthea --refresh run -o ./output --population 10 --state TX --city Austin
-
-# Advance 30 days from an initial snapshot and limit to CSV output only
-synthea run -o ./output --initial-snapshot snap.json --days-forward 30 --format CSV
-
-# Keep Synthea's default exporters AND also turn on CCDA (additive)
-synthea run -o ./output --population 10 --state OH --add-format CCDA
-
-# Print the java invocation that would be run, without running it
-synthea run -o ./output --population 5 --state OH --print-args
-
-# Debug-level logs (download URLs, cache hits, every internal step)
-synthea --verbose run -o ./output --population 5 --state OH
-
-# Suppress info logs; only warnings and errors print
-synthea --quiet run -o ./output --population 5 --state OH
-
-# Use a pre-downloaded JAR (air-gapped/CI) — skips the GitHub call entirely
-synthea run -o ./output --population 5 --state OH --jar /opt/synthea-with-dependencies.jar
-
-# Fail fast if the upstream release ships no .sha256 (recommended in CI)
-synthea run -o ./output --population 5 --state OH --insist-checksum
+dotnet tool install --global synthea-cli
+# To upgrade later:
+dotnet tool update --global synthea-cli
 ```
 
 > **Short alias:** `syn` works everywhere `synthea` does.
 
-### Configuration
+### First run
 
-Four sources can supply the JAR-management settings, in this precedence
-order — earlier wins:
+```bash
+# 10 synthetic Ohio patients in FHIR R4 (Synthea's default exporter)
+synthea run -o ./output -p 10 --state OH
 
-1. **CLI flag** — `--jar <path>`, `--insist-checksum`.
-2. **Environment variable** — `SYNTHEA_CLI_JAR_PATH`, `GITHUB_TOKEN`,
-   `HTTPS_PROXY` / `HTTP_PROXY`, `SYNTHEA_CLI_INSIST_CHECKSUM`.
+# Inspect what landed:
+#   ./output/fhir/*.json    <- one FHIR Bundle per patient
+#   ./output/metadata/      <- runtime parameters captured
+```
+
+First invocation downloads the Synthea JAR (~180 MB) from GitHub releases. Subsequent runs hit the local cache.
+
+---
+
+## Common scenarios
+
+### Multi-format export (FHIR + CSV + CCDA in one run)
+
+```bash
+synthea run -o ./output -p 50 --state OH `
+    --add-format CSV `
+    --add-format CCDA
+# Outputs:
+#   ./output/fhir/*.json      (default; one Bundle per patient)
+#   ./output/csv/*.csv        (patients, encounters, conditions, medications, ...)
+#   ./output/ccda/*.xml       (one CCDA document per patient)
+```
+
+`--add-format` is **additive** — adds the named format alongside Synthea's default FHIR output. Use `--format` instead if you want **exclusive** behavior (only the named format, all others disabled). Valid format names: `FHIR`, `CSV`, `CCDA`, `BULKFHIR`, `CPCDS`.
+
+### Reproducible fixtures (same seed → same patients)
+
+```bash
+synthea run -o ./output -p 25 --state OH --seed 42
+# Identical command on any machine produces identical patients.
+```
+
+### City and ZIP filters
+
+```bash
+# All patients live in Cleveland
+synthea run -o ./output -p 25 --state OH --city Cleveland
+
+# All patients in a specific ZIP
+synthea run -o ./output -p 25 --state OH --zip 44101
+```
+
+### Demographic filters
+
+```bash
+# Only female patients, ages 30-50
+synthea run -o ./output -p 25 --state OH --gender F --age-range 30-50
+```
+
+### Air-gapped use (pre-downloaded JAR)
+
+```bash
+# Skip the GitHub fetch entirely — point at a JAR you staged yourself
+synthea run -o ./output -p 25 --state OH --jar /opt/synthea-with-dependencies.jar
+```
+
+### Behind a corporate proxy + with a GitHub token
+
+```bash
+# Token avoids the 60-req/hour anonymous GitHub API limit (matters in CI)
+$env:GITHUB_TOKEN = "ghp_..."
+$env:HTTPS_PROXY = "http://corp-proxy:8080"
+synthea run -o ./output -p 25 --state OH
+```
+
+Or set both permanently in `~/.synthea-cli/config.json` (see [Configuration](#configuration)).
+
+### Supply-chain hardening
+
+```bash
+# Fail the run if the upstream release does not ship a .sha256 asset
+synthea run -o ./output -p 25 --state OH --insist-checksum
+```
+
+### Inspect what would be invoked (without running)
+
+```bash
+synthea run -o ./output -p 25 --state OH --print-args
+# Prints the exact `java -jar ...` command, then exits.
+# Useful for debugging or building CI shell scripts.
+```
+
+### Verbosity
+
+```bash
+# Debug-level logs (download URLs, cache hits, every internal step)
+synthea --verbose run -o ./output -p 5 --state OH
+
+# Warnings/errors only (good for CI logs)
+synthea --quiet run -o ./output -p 5 --state OH
+```
+
+---
+
+## Cache management
+
+The downloaded Synthea JAR is cached under `%LOCALAPPDATA%\Synthea.Cli` on Windows and `~/.local/share/Synthea.Cli` on Linux/macOS. Two sub-commands surface the cache without a file manager:
+
+```bash
+# List cached JARs with their size and last-modified date
+synthea cache list
+
+# Delete every cached JAR (with confirmation; pass --yes to skip)
+synthea cache clear --yes
+
+# Or force a fresh download on the next run
+synthea --refresh run -o ./output -p 5 --state OH
+```
+
+---
+
+## Configuration
+
+Four sources can supply JAR-management settings, in precedence order (earlier wins):
+
+1. **CLI flag** — `--jar <path>`, `--insist-checksum`
+2. **Environment variable** — `SYNTHEA_CLI_JAR_PATH`, `GITHUB_TOKEN`, `HTTPS_PROXY` / `HTTP_PROXY`, `SYNTHEA_CLI_INSIST_CHECKSUM`
 3. **Config file** — `~/.synthea-cli/config.json`:
 
    ```json
@@ -106,29 +189,18 @@ order — earlier wins:
      "httpsProxy": "http://corp-proxy:8080"
    }
    ```
+
 4. **Built-in default** — download the latest release JAR from GitHub.
 
-`GITHUB_TOKEN` (when set) is attached as `Authorization: Bearer <token>`
-on GitHub API calls so anonymous runs don't hit the 60 req/hour rate limit.
-`HTTPS_PROXY` is wired into the HTTP client at startup. `--insist-checksum`
-fails the run if the upstream release does not publish a `.sha256` asset
-(default off for backward compatibility — recommended on in production CI).
+**Notes:**
+- `GITHUB_TOKEN` (when set) is attached as `Authorization: Bearer <token>` on GitHub API calls so anonymous CI runs don't hit the 60-req/hour rate limit.
+- `HTTPS_PROXY` is wired into the HTTP client at startup.
+- `--insist-checksum` fails the run if the upstream release does not publish a `.sha256` asset (default off for backward compatibility — recommended on in production CI).
+- Token is per-request, not stored on the HTTP client default headers, so it doesn't leak to non-GitHub URLs.
 
-### Cache management
+---
 
-The downloaded Synthea JAR is cached under `%LOCALAPPDATA%\Synthea.Cli`
-on Windows and `~/.local/share/Synthea.Cli` on Linux/macOS. Two
-sub-commands surface the cache directly without needing a file manager:
-
-```bash
-# List cached JARs with their size and last-modified date
-synthea cache list
-
-# Delete every cached JAR (with confirmation; pass --yes to skip)
-synthea cache clear --yes
-```
-
-### Exit codes
+## Exit codes
 
 | Code | Meaning |
 |------|---------|
@@ -141,169 +213,102 @@ synthea cache clear --yes
 
 ---
 
-## Developer Guide
+## Architecture
 
-### Clone & Build
+- **Container:** single .NET 10 process spawning `java -jar synthea-with-dependencies.jar`
+- **JAR management:** GitHub API client + filesystem cache with optional SHA-256 verification
+- **Configuration:** four-source precedence resolver (CLI > env > config file > default)
+- **DI:** `Microsoft.Extensions.DependencyInjection` wires `IProcessRunner`, `IJarSource`, `ILogger<T>`
+- **Validation:** option validators reject bad input before launching the JAR (state codes, ZIP shapes, gender, age range, format names, file existence, etc.)
 
-```bash
-git clone https://github.com/Kmanley1/Synthea.Cli.git
-cd Synthea.Cli
-dotnet restore
-dotnet build
-dotnet run -- run -o ./out --population 5 --state AK
-```
-
-### Unit Tests
-
-```bash
-dotnet test --collect:"XPlat Code Coverage"
-# Coverage report in ./TestResults/**/coverage.cobertura.xml
-```
-
-The project includes **37 comprehensive tests**:
-- **33 unit tests** covering all CLI functionality, validation logic, and edge cases
-- **4 integration tests** with actual Java/Synthea execution and file generation validation
-
-All tests use xUnit framework with full mocking for network and process calls.
-
-#### Auto-Fix for Package Corruption
-
-The test infrastructure includes automatic detection and repair of NuGet package corruption:
-
-```bash
-# Enhanced test setup with auto-fix capability
-.\setup-test-environment.ps1
-
-# VS Code tasks with auto-fix (Ctrl+Shift+P -> Tasks: Run Task)
-test-with-autofix              # Run tests with automatic corruption fix
-setup-test-environment         # Full environment setup
-
-# Manual corruption fix if needed
-.\fix-java-detection.ps1       # Repair corrupted NuGet packages
-```
-
-**Auto-fix triggers on these errors:**
-- `The type or namespace name 'Xunit' could not be found`
-- `Package [name], version [version] was not found`  
-- `NuGet restore might have only partially completed`
-
-The system automatically clears caches, restores packages, rebuilds, and re-runs tests.
-
-### Docker
-
-> **Status:** Planned. A Dockerfile is not yet included in this version.
-> The example below is illustrative of the intended usage once one is added.
-
-```bash
-# Illustrative only — requires a Dockerfile to be added first.
-docker build -t synthea.cli .
-docker run --rm -v "$PWD/out":/data synthea.cli run --output /data --state CA --population 100
-```
-
-
-### `setup.sh` for CI / Codex
-
-The setup script has moved to `tools/setup.sh` for better project organization.
-
-`tools/setup.sh` does:
-
-1. Installs OpenJDK 11 and .NET 8 on Ubuntu runners  
-2. Restores & publishes `Synthea.Cli` to `/workspace/synthea-cli/bin`
-
-#### GitHub Actions example
-
-
-```yaml
-steps:
-  - uses: actions/checkout@v4
-  - run: ./tools/setup.sh
-  - run: dotnet /workspace/synthea-cli/bin/Synthea.Cli.dll -- --help
-```
-
-### Running Integration Tests
-
-Execute all integration tests with:
-
-```bash
-dotnet test --filter Category=Integration
-```
-
-This builds the CLI and runs cross-platform tests including `ScaffoldingSmokeTest`, `SyntheaRunTests`,
-and `SyntheaCliWrapperRunTests`.
+See [docs/deliverables/Architecture.md](docs/deliverables/Architecture.md) for the C4-style architecture document and [docs/adr/](docs/adr/) for the five Architecture Decision Records covering: DI container, JAR caching, System.CommandLine GA migration, `--format` semantics, and passthru token ordering.
 
 ---
 
-## Project Layout
+## Developer guide
+
+### Clone & build
+
+```bash
+git clone https://github.com/Kmanley1/SyntheaCli.git
+cd SyntheaCli
+dotnet restore
+dotnet build
+dotnet run --project src/Synthea.Cli -- run -o ./out -p 5 --state OH
+```
+
+### Tests
+
+```bash
+# Unit tests (fast; default; ~104 tests)
+dotnet test --filter "Category!=Integration"
+
+# Integration tests (require Java on PATH; ~3 tests; ~30s)
+dotnet test --filter Category=Integration
+
+# With coverage
+dotnet test tests/Synthea.Cli.UnitTests/Synthea.Cli.UnitTests.csproj `
+    --collect:"XPlat Code Coverage"
+# Coverage report in ./TestResults/**/coverage.cobertura.xml
+```
+
+Coverage gate (enforced in CI): **≥ 80% line, ≥ 75% branch**. Current baseline: 86.96% line / 82.84% branch.
+
+### Cross-platform CI
+
+GitHub Actions matrix runs on `ubuntu-latest` and `windows-latest` for every PR. CodeQL scans on every push. Dependabot keeps NuGet and GitHub Actions packages current.
+
+### Releasing
+
+Tag a version (`vX.Y.Z`) and push. `.github/workflows/nuget.yml` runs `dotnet pack` and `dotnet nuget push` automatically.
+
+```bash
+git tag -a v0.4.1 -m "..."
+git push origin v0.4.1
+```
+
+### Useful project structure
 
 ```text
 SyntheaCli/
-├─ .gitattributes                # enforce LF for shell scripts
-├─ .gitignore
-├─ README.md
-├─ Synthea.Cli.code-workspace    # VS Code workspace file
-├─ Directory.Build.props         # Shared MSBuild settings (TreatWarningsAsErrors, Nullable)
-├─ Synthea.Cli.sln               # Visual Studio solution
-├─ tools/
-│   ├─ setup.sh                  # CI / Linux build script
-│   ├─ setup.ps1                 # CI / Windows build script  
-│   └─ windows/
-│       ├─ install-vscode-extensions.ps1
-│       ├─ synthea-cli-create.ps1 # helper to scaffold new CLI repo
-│       └─ nuget-helper.ps1
-├─ setup-test-environment.ps1    # Test environment setup for Windows
-├─ docs/
-│   ├─ deliverables/             # Project documentation and analysis
-│   ├─ prompts/                  # AI automation templates
-│   ├─ reference/                # External documentation  
-│   └─ research/                 # Research materials
-├─ src/Synthea.Cli/              # main CLI project
-│   ├─ Program.cs                # System.CommandLine entry point
-│   ├─ RunCommand.cs             # Run command implementation
-│   ├─ RunOptions.cs             # Command options definitions
-│   ├─ JarManager.cs             # JAR download & cache helper
-│   ├─ ProcessHelpers.cs         # Process execution utilities
+├─ src/Synthea.Cli/                  # CLI source
+│   ├─ Program.cs                    # DI composition + dispatch
+│   ├─ RunCommand.cs                 # `run` subcommand + option definitions
+│   ├─ CacheCommand.cs               # `cache list` / `cache clear`
+│   ├─ JarManager.cs                 # GitHub download + cache + checksum
+│   ├─ CliConfig.cs                  # 4-source precedence resolver
+│   ├─ UsStates.cs                   # USPS code <-> full name lookup
+│   ├─ ProcessHelpers.cs             # IProcessRunner / DefaultProcessRunner
 │   └─ Synthea.Cli.csproj
 ├─ tests/
-│   ├─ Synthea.Cli.UnitTests/           # unit tests (xUnit)
-│   │   ├─ CliTests.cs
-│   │   ├─ JarManagerTests.cs
-│   │   ├─ ProgramHandlerTests.cs
-│   │   ├─ ProgramRefactorTests.cs
-│   │   └─ Synthea.Cli.UnitTests.csproj
-│   └─ Synthea.Cli.IntegrationTests/     # integration tests (xUnit)
-│       ├─ ScaffoldingSmokeTest.cs
-│       ├─ SyntheaRunTests.cs
-│       ├─ SyntheaCliWrapperRunTests.cs
-│       ├─ SkipTestException.cs
-│       └─ Synthea.Cli.IntegrationTests.csproj
-└─ third-party/                  # External dependencies and libraries
-    └─ MPXJ.Net/
+│   ├─ Synthea.Cli.UnitTests/        # 104 unit tests, full mocks
+│   └─ Synthea.Cli.IntegrationTests/ # cross-platform end-to-end
+├─ docs/
+│   ├─ deliverables/Architecture.md  # C4-style architecture
+│   └─ adr/                          # 5 Architecture Decision Records
+├─ .github/workflows/                # ci.yml, nuget.yml, codeql.yml
+├─ tools/                            # setup.sh / setup.ps1 (CI bootstrap)
+└─ Synthea.Cli.sln
 ```
 
 ---
 
 ## Contributing
 
-1. Fork → feature branch → PR.  
-2. Ensure `dotnet test` passes and coverage ≥ 90 %.  
-3. If you add new dependencies, update both `.csproj` files and `tools/setup.sh`.  
-4. Follow `dotnet format` / `.editorconfig` (4-space indents, C# latest).
+1. Fork → feature branch → PR
+2. Ensure `dotnet test` passes; coverage gate (80% line / 75% branch) holds
+3. Run `dotnet format --verify-no-changes --severity warn` (CI enforces it)
+4. Follow Conventional Commits in your PR title (e.g. `feat(run): ...`, `fix(jar): ...`, `docs: ...`)
 
-Issues and feature requests welcome!
-
----
-
-## License & Credits
-
-- **Tool code** © 2025 Ken Manley — MIT License (`LICENSE`).  
-
-- **Synthea™** is © MITRE, Apache-2.0. This CLI downloads the official Synthea JAR but is **not** an official MITRE project.  
-- Uses **System.CommandLine** (`2.0.0-beta4`) under MIT.
+Issues and feature requests welcome — see [docs/adr/](docs/adr/) for context on prior design decisions before proposing changes that touch them.
 
 ---
+
+## License & credits
+
+- **Tool code** © 2026 Ken Manley — [MIT License](LICENSE)
+- **Synthea™** is © MITRE Corporation, licensed [Apache-2.0](https://github.com/synthetichealth/synthea/blob/master/LICENSE). This CLI downloads the official Synthea JAR but is **not** an official MITRE project.
+- Uses [System.CommandLine](https://github.com/dotnet/command-line-api) 2.0.x GA under MIT.
+- Uses [Microsoft.Extensions.DependencyInjection](https://github.com/dotnet/runtime) and [Microsoft.Extensions.Logging](https://github.com/dotnet/runtime) under MIT.
 
 Happy generating! 🎉
-
-## Architecture
-
-See [docs/deliverables/Architecture.md](docs/deliverables/Architecture.md) for detailed architectural information and design decisions.


### PR DESCRIPTION
## Summary

Restructures the README to lead with **use cases** ("what this does for you") rather than **implementation** ("a .NET wrapper"). Refreshes ~6 stale facts that no longer reflect the current codebase.

## Why

In our 2026-05-16 demo walkthrough we noticed the README opens with technical framing (".NET 8 CLI wrapper") instead of the value the tool delivers (realistic synthetic patient data for healthcare-data testing without HIPAA exposure). This is a real value-comms gap for first-time visitors.

This rewrite is also a prerequisite for the v0.5.0 feature work — we want the README narrative settled before we add the next batch of features so there's a coherent story to point at.

## What changed

**Structural:**
- Opens with a one-line hook + a working command
- New "Use it for" section: FHIR integration testing, EMR/HL7/CCDA pipelines, clinical data warehouses + OMOP, claims pipelines, reproducible fixtures
- New "Common scenarios" section with 9 worked examples (multi-format, reproducible seeding, geo filters, air-gapped, proxy+token, supply-chain hardening, --print-args, verbosity)
- New "Architecture" section linking to `docs/deliverables/Architecture.md` and the 5 ADRs
- New "Releasing" section documenting the tag-driven NuGet publish flow

**Stale information corrected:**
| Was | Now | Reason |
|-----|-----|--------|
| .NET 8 | .NET 10 | Upgraded in v0.4.0 (PR #66) |
| Java 11+ | Java 17+ | Synthea v4.0 dropped JDK 11 support 2026-03 |
| 37 tests | 104 tests | Current count after v0.3.x ralph backlog |
| Coverage ≥ 90% | 80% line / 75% branch | The actual enforced gate |
| Package `Synthea.Cli` | `synthea-cli` | Matches NuGet owner namespace; fixed in fb06f73 |
| System.CommandLine beta4 | 2.0.x GA | A-15 |

**Removed:**
- "Docker" section (status was "planned"; will revisit when actually shipped)
- "Auto-Fix for Package Corruption" section (build-system internal that doesn't belong in user-facing README)
- Stale Project Layout (RunOptions.cs split in A-28; missing CacheCommand, CliConfig, UsStates files)

## Scope

- ✅ Only `README.md` modified
- ✅ No source code changes
- ✅ No workflow / config changes

## Test plan

- [ ] CI green (just CodeQL since no code changed; .NET CI may skip or run as no-op)
- [ ] Render check on GitHub PR page (visually verify markdown tables, code blocks, links)
- [ ] Link audit: every internal link resolves (docs/deliverables/Architecture.md, docs/adr/, LICENSE)

## Related

Sets the stage for the v0.5.0 ralph plan tracked in `docs/SyntheaCli-notes-v-next.md` (planning workspace, local-only). The v0.5.0 plan adds ~25 features and assumes this README rewrite is already in place so we have a coherent narrative.