### PR TITLE
feat(jdk): fail fast on Java < 17 with clear message (C2)

### DIFF
--- a/docs/deliverables/Architecture.md
+++ b/docs/deliverables/Architecture.md
@@ -17,7 +17,7 @@ flowchart LR
     User([User / CI])
     SyntheaCli[Synthea.Cli<br/>.NET 8 global tool]
     GitHub[(GitHub Releases<br/>synthetichealth/synthea)]
-    Java[Java JRE 11+]
+    Java[Java JRE 17+]
     Output[(Local filesystem<br/>output directory)]
 
     User -->|run / cache list / cache clear| SyntheaCli
@@ -48,7 +48,7 @@ flowchart TB
         Cache[(JAR cache<br/>%LOCALAPPDATA%\Synthea.Cli<br/>~/.local/share/Synthea.Cli)]
         Config[(~/.synthea-cli/config.json)]
         Out[(./output/...)]
-        Java[Java JRE 11+]
+        Java[Java JRE 17+]
     end
     GitHub[(GitHub Releases API)]
 
@@ -63,7 +63,7 @@ flowchart TB
 |-----------|-----|
 | `synthea` CLI process | The tool itself; short-lived, one invocation per run |
 | JAR cache directory | Avoids re-downloading on every run; survives across invocations |
-| Java JRE | Hosts the actual Synthea simulation; user-provided |
+| Java JRE | Hosts the actual Synthea simulation; user-provided. Synthea v4.0 requires Java 17 or newer. |
 | Config file | Persistent settings (token, proxy, default JAR path) |
 | Output directory | User-controlled; the tool only ensures it exists |
 

--- a/src/Synthea.Cli/JavaDetector.cs
+++ b/src/Synthea.Cli/JavaDetector.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Synthea.Cli;
+
+internal sealed record JavaProbeResult(
+    bool Found,
+    int? MajorVersion,
+    string? RawVersionString,
+    string? ErrorMessage);
+
+internal interface IJavaDetector
+{
+    Task<JavaProbeResult> ProbeAsync(string javaPath, CancellationToken cancelToken = default);
+}
+
+internal sealed class JavaDetector : IJavaDetector
+{
+    private readonly IProcessRunner _runner;
+
+    public JavaDetector(IProcessRunner runner) => _runner = runner;
+
+    public async Task<JavaProbeResult> ProbeAsync(string javaPath, CancellationToken cancelToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(javaPath))
+            return new JavaProbeResult(false, null, null, "Java path was empty.");
+
+        var psi = new ProcessStartInfo(javaPath, "-version")
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        try
+        {
+            using var proc = _runner.Start(psi);
+            // `java -version` prints to stderr, but redirect both to be safe.
+            var stderr = proc.StandardError.ReadToEndAsync(cancelToken);
+            var stdout = proc.StandardOutput.ReadToEndAsync(cancelToken);
+            await Task.WhenAll(stderr, stdout, proc.WaitForExitAsync());
+            return Parse(stderr.Result + stdout.Result);
+        }
+        catch (Exception ex)
+        {
+            return new JavaProbeResult(false, null, null, ex.Message);
+        }
+    }
+
+    // Old style: "java version "1.8.0_201"" — major version is the integer after the leading "1.".
+    // New style (Java 9+): "openjdk version "21.0.5"" — major version is the first integer.
+    internal static JavaProbeResult Parse(string output)
+    {
+        if (string.IsNullOrEmpty(output))
+            return new JavaProbeResult(false, null, null, "Empty output from java -version.");
+
+        var match = Regex.Match(output, @"version\s+""(?<v>[\d._]+)""", RegexOptions.IgnoreCase);
+        if (!match.Success)
+            return new JavaProbeResult(false, null, null,
+                "Could not parse Java version from output: " + output.Trim());
+
+        var raw = match.Groups["v"].Value;
+        var parts = raw.Split(new[] { '.', '_' }, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0 || !int.TryParse(parts[0], out var first))
+            return new JavaProbeResult(false, null, raw, "Could not parse major version from: " + raw);
+
+        var major = first == 1 && parts.Length > 1 && int.TryParse(parts[1], out var second)
+            ? second
+            : first;
+        return new JavaProbeResult(true, major, raw, null);
+    }
+}

--- a/src/Synthea.Cli/Program.cs
+++ b/src/Synthea.Cli/Program.cs
@@ -40,6 +40,7 @@ internal static class Program
                 o.TimestampFormat = "HH:mm:ss ";
             }));
         sc.AddSingleton<IProcessRunner, DefaultProcessRunner>();
+        sc.AddSingleton<IJavaDetector, JavaDetector>();
         sc.AddSingleton<IJarSource>(sp => new JarManager(
             http: BuildHttpClient(CliConfig.Load()),
             logger: sp.GetRequiredService<ILogger<JarManager>>()));
@@ -69,6 +70,7 @@ internal static class Program
     {
         var runner = services.GetRequiredService<IProcessRunner>();
         var jarSource = services.GetRequiredService<IJarSource>();
+        var javaDetector = services.GetRequiredService<IJavaDetector>();
 
         var root = new RootCommand("CLI wrapper around MITRE Synthea synthetic patient generator");
 
@@ -96,12 +98,20 @@ internal static class Program
             Recursive = true
         };
 
+        var skipJdkCheckOpt = new Option<bool>("--skip-jdk-check")
+        {
+            Description = "Bypass the Java 17+ preflight check. Use only for custom JREs whose " +
+                          "-version output we can't parse; otherwise fix Java first.",
+            Recursive = true
+        };
+
         root.Options.Add(refreshOpt);
         root.Options.Add(javaOpt);
         root.Options.Add(verboseOpt);
         root.Options.Add(quietOpt);
+        root.Options.Add(skipJdkCheckOpt);
 
-        root.Subcommands.Add(RunCommand.Build(runner, jarSource, refreshOpt, javaOpt));
+        root.Subcommands.Add(RunCommand.Build(runner, jarSource, javaDetector, refreshOpt, javaOpt, skipJdkCheckOpt));
         root.Subcommands.Add(CacheCommand.Build(jarSource));
 
         if (args.Length == 0) args = new[] { "--help" };

--- a/src/Synthea.Cli/RunCommand.cs
+++ b/src/Synthea.Cli/RunCommand.cs
@@ -19,7 +19,8 @@ internal static class RunCommand
         "fhir", "csv", "ccda", "bulkfhir", "bulk-fhir", "cpcds"
     };
 
-    internal static Command Build(IProcessRunner runner, IJarSource jarSource, Option<bool> refreshOpt, Option<string?> javaOpt)
+    internal static Command Build(IProcessRunner runner, IJarSource jarSource, IJavaDetector javaDetector,
+        Option<bool> refreshOpt, Option<string?> javaOpt, Option<bool> skipJdkCheckOpt)
     {
         var runCmd = new Command("run", "Generate synthetic health records");
 
@@ -108,6 +109,30 @@ internal static class RunCommand
             if (printArgs)
             {
                 return PrintInvocation(hosting, args, jarSource);
+            }
+
+            var skipJdk = parseResult.GetValue(skipJdkCheckOpt);
+            if (!skipJdk)
+            {
+                var probe = await javaDetector.ProbeAsync(hosting.JavaPath, cancelToken);
+                if (!probe.Found)
+                {
+                    Console.Error.WriteLine($"Java not found at '{hosting.JavaPath}'. Use --java-path or install OpenJDK 17 LTS.");
+                    if (!string.IsNullOrWhiteSpace(probe.ErrorMessage))
+                        Console.Error.WriteLine($"Details: {probe.ErrorMessage}");
+                    return 3;
+                }
+                if (probe.MajorVersion is { } major && major < 17)
+                {
+                    Console.Error.WriteLine(
+                        $"Synthea requires Java 17 or later (found Java {major}). " +
+                        "Install OpenJDK 17 LTS or newer; see https://adoptium.net.");
+                    return 1;
+                }
+            }
+            else
+            {
+                Console.Error.WriteLine("warning: --skip-jdk-check set; bypassing Java 17+ preflight.");
             }
 
             Directory.CreateDirectory(hosting.Output.FullName);

--- a/tests/Synthea.Cli.IntegrationTests/SyntheaRunTests.cs
+++ b/tests/Synthea.Cli.IntegrationTests/SyntheaRunTests.cs
@@ -35,6 +35,7 @@ public class SyntheaRunTests : IDisposable
         var sc = new ServiceCollection();
         sc.AddSingleton<IProcessRunner>(new FakeRunner(outputDir));
         sc.AddSingleton<IJarSource>(new StubJarSource(jar));
+        sc.AddSingleton<IJavaDetector>(new StubJavaDetector());
         await using var services = sc.BuildServiceProvider();
 
         var exit = await Program.RunAsync(new[] { "run", "--output", _workDir, "--population", "1" }, services);
@@ -77,5 +78,11 @@ public class SyntheaRunTests : IDisposable
             CancellationToken token = default,
             JarOverrides? overrides = null)
             => Task.FromResult(_jar);
+    }
+
+    private sealed class StubJavaDetector : IJavaDetector
+    {
+        public Task<JavaProbeResult> ProbeAsync(string javaPath, CancellationToken cancelToken = default)
+            => Task.FromResult(new JavaProbeResult(true, 21, "21.0.5", null));
     }
 }

--- a/tests/Synthea.Cli.UnitTests/CacheCommandTests.cs
+++ b/tests/Synthea.Cli.UnitTests/CacheCommandTests.cs
@@ -25,6 +25,7 @@ public class CacheCommandTests : IDisposable
         var sc = new ServiceCollection();
         sc.AddSingleton<IProcessRunner>(new NoopRunner());
         sc.AddSingleton<IJarSource>(new FixedPathJarSource(_cacheDir));
+        sc.AddSingleton<IJavaDetector>(new StubJavaDetector());
         _services = sc.BuildServiceProvider();
     }
 
@@ -120,5 +121,11 @@ public class CacheCommandTests : IDisposable
     {
         public IProcess Start(System.Diagnostics.ProcessStartInfo psi)
             => throw new NotSupportedException();
+    }
+
+    private sealed class StubJavaDetector : IJavaDetector
+    {
+        public Task<JavaProbeResult> ProbeAsync(string javaPath, CancellationToken cancelToken = default)
+            => Task.FromResult(new JavaProbeResult(true, 21, "21.0.5", null));
     }
 }

--- a/tests/Synthea.Cli.UnitTests/JavaDetectorTests.cs
+++ b/tests/Synthea.Cli.UnitTests/JavaDetectorTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Synthea.Cli;
+using Xunit;
+
+namespace Synthea.Cli.UnitTests;
+
+public class JavaDetectorTests
+{
+    [Fact]
+    public void JavaDetector_Parses_OpenJDK17()
+    {
+        const string output = "openjdk version \"17.0.10\" 2024-01-16 LTS\n" +
+                              "OpenJDK Runtime Environment Temurin-17.0.10+7 (build 17.0.10+7-LTS)\n";
+        var r = JavaDetector.Parse(output);
+        Assert.True(r.Found);
+        Assert.Equal(17, r.MajorVersion);
+        Assert.Equal("17.0.10", r.RawVersionString);
+        Assert.Null(r.ErrorMessage);
+    }
+
+    [Fact]
+    public void JavaDetector_Parses_OracleJDK21()
+    {
+        const string output = "java version \"21.0.5\" 2024-10-15 LTS\n" +
+                              "Java(TM) SE Runtime Environment (build 21.0.5+9-LTS-239)\n";
+        var r = JavaDetector.Parse(output);
+        Assert.True(r.Found);
+        Assert.Equal(21, r.MajorVersion);
+        Assert.Equal("21.0.5", r.RawVersionString);
+    }
+
+    [Fact]
+    public void JavaDetector_Parses_OldJava11()
+    {
+        const string output = "openjdk version \"11.0.20\" 2023-07-18\n" +
+                              "OpenJDK Runtime Environment Temurin-11.0.20+8\n";
+        var r = JavaDetector.Parse(output);
+        Assert.True(r.Found);
+        Assert.Equal(11, r.MajorVersion);
+    }
+
+    [Fact]
+    public void JavaDetector_Parses_LegacyJava8()
+    {
+        // Old "1.8.0_201" form — major version is the integer after the "1.".
+        const string output = "java version \"1.8.0_201\"\n" +
+                              "Java(TM) SE Runtime Environment (build 1.8.0_201-b09)\n";
+        var r = JavaDetector.Parse(output);
+        Assert.True(r.Found);
+        Assert.Equal(8, r.MajorVersion);
+    }
+
+    [Fact]
+    public void JavaDetector_Parses_GarbledOutput_ReportsNotFound()
+    {
+        var r = JavaDetector.Parse("totally not java output");
+        Assert.False(r.Found);
+        Assert.Null(r.MajorVersion);
+        Assert.NotNull(r.ErrorMessage);
+    }
+
+    [Fact]
+    public void JavaDetector_Parses_EmptyOutput_ReportsNotFound()
+    {
+        var r = JavaDetector.Parse(string.Empty);
+        Assert.False(r.Found);
+    }
+
+    [Fact]
+    public async Task JavaDetector_HandlesMissingJava()
+    {
+        var runner = new ThrowingRunner();
+        var detector = new JavaDetector(runner);
+        var r = await detector.ProbeAsync("definitely-not-a-real-binary-9c4e1a");
+        Assert.False(r.Found);
+        Assert.NotNull(r.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task JavaDetector_ProbeAsync_DelegatesToRunner_ParsesStderr()
+    {
+        var runner = new StubRunner(stderr: "openjdk version \"21.0.5\" 2024-10-15 LTS\n", stdout: "");
+        var detector = new JavaDetector(runner);
+        var r = await detector.ProbeAsync("java");
+        Assert.True(r.Found);
+        Assert.Equal(21, r.MajorVersion);
+    }
+
+    [Fact]
+    public async Task JavaDetector_ProbeAsync_EmptyPath_ReturnsNotFound()
+    {
+        var detector = new JavaDetector(new ThrowingRunner());
+        var r = await detector.ProbeAsync("");
+        Assert.False(r.Found);
+        Assert.Equal("Java path was empty.", r.ErrorMessage);
+    }
+
+    private sealed class ThrowingRunner : IProcessRunner
+    {
+        public IProcess Start(ProcessStartInfo psi) => throw new FileNotFoundException("nope");
+    }
+
+    private sealed class StubRunner : IProcessRunner
+    {
+        private readonly string _stderr;
+        private readonly string _stdout;
+        public StubRunner(string stderr, string stdout) { _stderr = stderr; _stdout = stdout; }
+        public IProcess Start(ProcessStartInfo psi) => new StubProcess(_stdout, _stderr);
+
+        private sealed class StubProcess : IProcess
+        {
+            public StubProcess(string stdout, string stderr)
+            {
+                StandardOutput = new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(stdout)));
+                StandardError = new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(stderr)));
+            }
+            public StreamReader StandardOutput { get; }
+            public StreamReader StandardError { get; }
+            public int ExitCode => 0;
+            public Task WaitForExitAsync() => Task.CompletedTask;
+            public void Dispose() { }
+        }
+    }
+}

--- a/tests/Synthea.Cli.UnitTests/ProgramHandlerTests.cs
+++ b/tests/Synthea.Cli.UnitTests/ProgramHandlerTests.cs
@@ -14,6 +14,7 @@ public class ProgramHandlerTests : IDisposable
     private readonly string _tempDir;
     private readonly FileInfo _jar;
     private readonly CapturingRunner _runner = new();
+    private readonly StubJavaDetector _detector = new();
     private readonly ServiceProvider _services;
 
     public ProgramHandlerTests()
@@ -26,6 +27,7 @@ public class ProgramHandlerTests : IDisposable
         var sc = new ServiceCollection();
         sc.AddSingleton<IProcessRunner>(_runner);
         sc.AddSingleton<IJarSource>(new StubJarSource(_jar));
+        sc.AddSingleton<IJavaDetector>(_detector);
         _services = sc.BuildServiceProvider();
     }
 
@@ -390,5 +392,53 @@ public class ProgramHandlerTests : IDisposable
             CancellationToken token = default,
             JarOverrides? overrides = null)
             => Task.FromResult(_jar);
+    }
+
+    private sealed class StubJavaDetector : IJavaDetector
+    {
+        public JavaProbeResult Result { get; set; } = new(true, 21, "21.0.5", null);
+        public Task<JavaProbeResult> ProbeAsync(string javaPath, CancellationToken cancelToken = default)
+            => Task.FromResult(Result);
+    }
+
+    [Fact]
+    public async Task JdkCheck_TooOldJava_ExitsOneWithoutDownloading()
+    {
+        _detector.Result = new JavaProbeResult(true, 11, "11.0.20", null);
+        var outDir = Path.Combine(_tempDir, "out-jdk-old");
+        var code = await Run("run", "--output", outDir, "--state", "OH");
+        Assert.Equal(1, code);
+        // RunCommand should have rejected before invoking the process runner.
+        Assert.Null(_runner.StartInfo);
+    }
+
+    [Fact]
+    public async Task JdkCheck_JavaMissing_ExitsThreeWithoutDownloading()
+    {
+        _detector.Result = new JavaProbeResult(false, null, null, "not found");
+        var outDir = Path.Combine(_tempDir, "out-jdk-missing");
+        var code = await Run("run", "--output", outDir, "--state", "OH");
+        Assert.Equal(3, code);
+        Assert.Null(_runner.StartInfo);
+    }
+
+    [Fact]
+    public async Task JdkCheck_SkipFlag_BypassesCheckEvenWhenJavaTooOld()
+    {
+        _detector.Result = new JavaProbeResult(true, 8, "1.8.0_201", null);
+        var outDir = Path.Combine(_tempDir, "out-jdk-skip");
+        var code = await Run("run", "--output", outDir, "--state", "OH", "--skip-jdk-check");
+        Assert.Equal(0, code);
+        Assert.NotNull(_runner.StartInfo);
+    }
+
+    [Fact]
+    public async Task JdkCheck_Java17_Passes()
+    {
+        _detector.Result = new JavaProbeResult(true, 17, "17.0.10", null);
+        var outDir = Path.Combine(_tempDir, "out-jdk-17");
+        var code = await Run("run", "--output", outDir, "--state", "OH");
+        Assert.Equal(0, code);
+        Assert.NotNull(_runner.StartInfo);
     }
 }

--- a/tests/Synthea.Cli.UnitTests/ProgramRefactorTests.cs
+++ b/tests/Synthea.Cli.UnitTests/ProgramRefactorTests.cs
@@ -25,7 +25,9 @@ public class ProgramRefactorTests
     {
         var refreshOpt = new Option<bool>("--refresh");
         var javaOpt = new Option<string?>("--java-path");
-        var run = RunCommand.Build(new NoopRunner(), new NoopJarSource(), refreshOpt, javaOpt);
+        var skipJdkOpt = new Option<bool>("--skip-jdk-check");
+        var run = RunCommand.Build(new NoopRunner(), new NoopJarSource(), new StubDetector(),
+            refreshOpt, javaOpt, skipJdkOpt);
 
         var stateOpt = run.Options.Single(o => o.Name == "--state");
         Assert.NotEmpty(stateOpt.Validators);
@@ -223,6 +225,12 @@ public class ProgramRefactorTests
     private sealed class NoopRunner : IProcessRunner
     {
         public IProcess Start(ProcessStartInfo psi) => throw new NotSupportedException();
+    }
+
+    private sealed class StubDetector : IJavaDetector
+    {
+        public Task<JavaProbeResult> ProbeAsync(string javaPath, CancellationToken cancelToken = default)
+            => Task.FromResult(new JavaProbeResult(true, 21, "21.0.5", null));
     }
 
     private sealed class NoopJarSource : IJarSource


### PR DESCRIPTION
## Summary
- New `JavaDetector` probes `java -version` (parses both legacy `1.X` and modern `X.Y.Z` formats), reports MajorVersion.
- `RunCommand` calls the detector before downloading the JAR or spawning java: exit 1 on Java < 17, exit 3 on missing java.
- New global `--skip-jdk-check` flag bypasses the preflight for edge cases (custom JREs whose -version output isn't parseable).
- `docs/deliverables/Architecture.md` updated to reflect Synthea v4.0's Java 17+ requirement.

Implements v-next **C2** (JDK 17 preflight).

## Test plan
- [x] JavaDetector parses OpenJDK 17, Oracle JDK 21, OpenJDK 11, legacy Java 8
- [x] JavaDetector handles missing java / garbled output / empty output / empty path
- [x] RunCommand exits 1 on Java < 17 without downloading JAR
- [x] RunCommand exits 3 on missing java without downloading JAR
- [x] `--skip-jdk-check` bypasses check even on Java 8
- [x] Java 17 / 21 pass the check and proceed to launch
- [x] `dotnet build` clean (warnings-as-errors)
- [x] `dotnet test --filter "Category!=Integration"` 117 passed, 0 failed
- [x] `dotnet format --verify-no-changes --severity warn` clean