### PR TITLE
feat(config): exit non-zero on malformed config JSON (C7)

### DIFF
--- a/src/Synthea.Cli/CliConfig.cs
+++ b/src/Synthea.Cli/CliConfig.cs
@@ -39,10 +39,36 @@ internal sealed record CliConfig(
         }
         catch (JsonException)
         {
-            // A malformed config file should not be a hard failure for every
-            // run — fall back to defaults and let the user fix it on their
-            // own time. Surfaced to the user via the logger by the caller.
+            // Tolerant variant: callers (e.g. synthea doctor in Phase 9) want
+            // to report on a bad config rather than crash. Run path uses
+            // LoadOrThrow() to fail fast instead. (C7)
             return Empty;
+        }
+    }
+
+    // Strict variant: throws CliConfigException on malformed JSON so the
+    // caller can map it to a clean exit code 1 with a one-line error. Used
+    // by RunCommand to honor C7: malformed config is always an error.
+    public static CliConfig LoadOrThrow(string? path = null)
+    {
+        path ??= DefaultPath();
+        if (!File.Exists(path)) return Empty;
+        string json;
+        try
+        {
+            json = File.ReadAllText(path);
+        }
+        catch (IOException ex)
+        {
+            throw new CliConfigException($"config: {path}: could not read file: {ex.Message}");
+        }
+        try
+        {
+            return JsonSerializer.Deserialize<CliConfig>(json, JsonOpts) ?? Empty;
+        }
+        catch (JsonException ex)
+        {
+            throw new CliConfigException($"config: {path}: {ex.Message}");
         }
     }
 
@@ -86,4 +112,13 @@ internal sealed record CliConfig(
         if (configValue.HasValue) return configValue.Value;
         return @default;
     }
+}
+
+// Thrown by CliConfig.LoadOrThrow when ~/.synthea-cli/config.json is
+// present but malformed. Deliberately does NOT inherit from
+// InvalidOperationException so RunCommand's JarManager catch handler
+// doesn't accidentally classify a config error as a JAR error. (C7)
+internal sealed class CliConfigException : Exception
+{
+    public CliConfigException(string message) : base(message) { }
 }

--- a/src/Synthea.Cli/RunCommand.cs
+++ b/src/Synthea.Cli/RunCommand.cs
@@ -93,7 +93,21 @@ internal static class RunCommand
                 fhirVerOpt, initialSnapOpt, updatedSnapOpt, daysForwardOpt, formatOpt, addFormatOpt,
                 jarOpt, insistChecksumOpt, passthru);
             var printArgs = parseResult.GetValue(printArgsOpt);
-            var jarOverrides = ResolveJarOverrides(hosting);
+
+            // C7: malformed ~/.synthea-cli/config.json must fail the run with
+            // a clean exit 1 (not a stack trace, not exit 3 from the JAR
+            // catch). Load explicitly here so we can map the error cleanly.
+            CliConfig config;
+            try
+            {
+                config = CliConfig.LoadOrThrow();
+            }
+            catch (CliConfigException ex)
+            {
+                Console.Error.WriteLine($"error: {ex.Message}");
+                return 1;
+            }
+            var jarOverrides = ResolveJarOverrides(hosting, config, Environment.GetEnvironmentVariable);
 
             if (!string.IsNullOrWhiteSpace(args.City) && string.IsNullOrWhiteSpace(args.State))
             {

--- a/tests/Synthea.Cli.UnitTests/CliConfigTests.cs
+++ b/tests/Synthea.Cli.UnitTests/CliConfigTests.cs
@@ -68,6 +68,42 @@ public class CliConfigTests : IDisposable
     }
 
     [Fact]
+    public void LoadOrThrow_MalformedJson_Throws()
+    {
+        var path = Path.Combine(_tempDir, "broken.json");
+        File.WriteAllText(path, "{not valid json");
+        var ex = Assert.Throws<CliConfigException>(() => CliConfig.LoadOrThrow(path));
+        Assert.Contains(path, ex.Message);
+        Assert.StartsWith("config: ", ex.Message);
+    }
+
+    [Fact]
+    public void LoadOrThrow_Valid_ReturnsConfig()
+    {
+        var path = Path.Combine(_tempDir, "config.json");
+        File.WriteAllText(path, """{ "jarPath": "/x/y.jar" }""");
+        var c = CliConfig.LoadOrThrow(path);
+        Assert.Equal("/x/y.jar", c.JarPath);
+    }
+
+    [Fact]
+    public void LoadOrThrow_Missing_ReturnsEmpty()
+    {
+        var path = Path.Combine(_tempDir, "no-such.json");
+        var c = CliConfig.LoadOrThrow(path);
+        Assert.Same(CliConfig.Empty, c);
+    }
+
+    [Fact]
+    public void CliConfigException_DoesNotInheritInvalidOperationException()
+    {
+        // RunCommand has a catch (InvalidOperationException) for JarManager
+        // errors. CliConfigException must not be caught by it — config errors
+        // are distinct from JAR errors (exit 1 vs exit 3). (C7)
+        Assert.False(typeof(InvalidOperationException).IsAssignableFrom(typeof(CliConfigException)));
+    }
+
+    [Fact]
     public void Resolve_CliWinsOverEnvAndConfig()
     {
         var env = Env(("SYNTHEA_CLI_JAR_PATH", "/env/path"));


### PR DESCRIPTION
## Summary
- New \`CliConfig.LoadOrThrow()\` throws \`CliConfigException\` (custom Exception subclass, NOT \`InvalidOperationException\`, so the existing RunCommand JAR-error handler doesn't accidentally catch it).
- \`RunCommand\` explicitly LoadOrThrows at the top of the action; maps \`CliConfigException\` to exit 1 with \`error: config: <path>: <parse-error>\` on stderr.
- Existing \`CliConfig.Load()\` preserved for tolerant callers (e.g., \`synthea doctor\` Phase 9).

Implements v-next **C7** (malformed config is always an error, not opt-in).

## Test plan
- [x] \`LoadOrThrow_MalformedJson_Throws\` — bad JSON throws CliConfigException with path in message
- [x] \`LoadOrThrow_Valid_ReturnsConfig\` — valid JSON parses correctly
- [x] \`LoadOrThrow_Missing_ReturnsEmpty\` — absent file returns CliConfig.Empty
- [x] \`CliConfigException_DoesNotInheritInvalidOperationException\` — regression guard against future inheritance change
- [x] Existing \`Load_MalformedFile_ReturnsEmpty\` still passes (tolerant variant unchanged)
- [x] \`dotnet build\` clean | \`dotnet test\` 121 passed | \`dotnet format\` clean