### PR TITLE
feat(error): surface Synthea stderr with remediation hints (C6)

### DIFF
--- a/src/Synthea.Cli/ProcessHelpers.cs
+++ b/src/Synthea.Cli/ProcessHelpers.cs
@@ -47,4 +47,23 @@ internal static class ProcessHelpers
         while ((line = await src.ReadLineAsync()) is not null)
             dest.WriteLine(line);
     }
+
+    // Relay each line AND retain the last `capacity` lines in a ring buffer
+    // so the caller can inspect tail-of-stderr for a remediation match after
+    // the process exits non-zero. Buffer is bounded to avoid pinning a
+    // long-running Synthea run's full stderr in memory. (C6)
+    internal static async Task<IReadOnlyList<string>> RelayAndCapture(
+        StreamReader src, TextWriter dest, int capacity = 50)
+    {
+        if (capacity <= 0) throw new ArgumentOutOfRangeException(nameof(capacity));
+        var ring = new List<string>(capacity);
+        string? line;
+        while ((line = await src.ReadLineAsync()) is not null)
+        {
+            dest.WriteLine(line);
+            if (ring.Count >= capacity) ring.RemoveAt(0);
+            ring.Add(line);
+        }
+        return ring;
+    }
 }

--- a/src/Synthea.Cli/RunCommand.cs
+++ b/src/Synthea.Cli/RunCommand.cs
@@ -174,10 +174,21 @@ internal static class RunCommand
                     try { proc.Kill(entireProcessTree: true); } catch { /* already exited */ }
                 });
                 var pumpOut = Task.Run(() => ProcessHelpers.Relay(proc.StandardOutput, Console.Out));
-                var pumpErr = Task.Run(() => ProcessHelpers.Relay(proc.StandardError, Console.Error));
+                var pumpErr = Task.Run(() => ProcessHelpers.RelayAndCapture(proc.StandardError, Console.Error));
 
                 await Task.WhenAll(pumpOut, pumpErr, proc.WaitForExitAsync());
-                return proc.ExitCode;
+                var exitCode = proc.ExitCode;
+                if (exitCode != 0)
+                {
+                    var capturedStderr = string.Join('\n', pumpErr.Result);
+                    var hint = SyntheaErrorPatterns.TryGetRemediation(capturedStderr);
+                    if (hint is not null)
+                    {
+                        Console.Error.WriteLine();
+                        Console.Error.WriteLine($"hint: {hint}");
+                    }
+                }
+                return exitCode;
             }
             catch (OperationCanceledException)
             {

--- a/src/Synthea.Cli/SyntheaErrorPatterns.cs
+++ b/src/Synthea.Cli/SyntheaErrorPatterns.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Synthea.Cli;
+
+// Maps known Synthea-JAR error substrings to a one-line remediation hint
+// we can print after the underlying process exits non-zero. Keeps the
+// remediation knowledge out of RunCommand so adding a new pattern is one
+// table entry, not a control-flow change. (C6)
+internal static class SyntheaErrorPatterns
+{
+    // First match wins. Order from most-specific to most-generic.
+    private static readonly (string Substring, string Remediation)[] Patterns = new[]
+    {
+        ("Unable to select a random city id",
+         "Synthea couldn't find geography data for the requested state. Use a US state name (e.g. 'Ohio') or the synthea-cli 2-letter code (e.g. 'OH')."),
+        ("UnsupportedClassVersionError",
+         "Your Java is older than Synthea requires. Install OpenJDK 17 or later, or run `synthea doctor` to inspect your environment."),
+        ("OutOfMemoryError",
+         "Synthea ran out of heap. Set JAVA_OPTS=-Xmx4g (or higher) in your environment, then re-run. A first-class --java-heap flag is on the v0.5 roadmap."),
+        ("Could not allocate",
+         "Synthea ran out of heap. Set JAVA_OPTS=-Xmx4g (or higher) in your environment, then re-run."),
+        ("Could not find or load main class",
+         "JAR appears corrupted or unsupported. Try `synthea cache clear --yes` then re-run to re-download."),
+        ("NoClassDefFoundError",
+         "JAR appears corrupted or missing dependencies. Try `synthea cache clear --yes` then re-run to re-download."),
+        ("FileNotFoundException",
+         "Synthea couldn't open a required input file. Check paths passed to --module, --module-dir, --config, or --initial-snapshot."),
+    };
+
+    public static string? TryGetRemediation(string? stderrText)
+    {
+        if (string.IsNullOrEmpty(stderrText)) return null;
+        foreach (var (substring, remediation) in Patterns)
+        {
+            if (stderrText.Contains(substring, StringComparison.OrdinalIgnoreCase))
+                return remediation;
+        }
+        return null;
+    }
+}

--- a/tests/Synthea.Cli.UnitTests/ProgramHandlerTests.cs
+++ b/tests/Synthea.Cli.UnitTests/ProgramHandlerTests.cs
@@ -364,17 +364,25 @@ public class ProgramHandlerTests : IDisposable
     private class CapturingRunner : IProcessRunner
     {
         public ProcessStartInfo? StartInfo;
+        public int ExitCode { get; set; }
+        public string StderrText { get; set; } = string.Empty;
         public IProcess Start(ProcessStartInfo psi)
         {
             StartInfo = psi;
-            return new StubProcess();
+            return new StubProcess(ExitCode, StderrText);
         }
 
         private class StubProcess : IProcess
         {
+            private readonly int _exitCode;
+            public StubProcess(int exitCode, string stderrText)
+            {
+                _exitCode = exitCode;
+                StandardError = new StreamReader(new MemoryStream(System.Text.Encoding.UTF8.GetBytes(stderrText)));
+            }
             public StreamReader StandardOutput { get; } = new StreamReader(new MemoryStream());
-            public StreamReader StandardError { get; } = new StreamReader(new MemoryStream());
-            public int ExitCode => 0;
+            public StreamReader StandardError { get; }
+            public int ExitCode => _exitCode;
             public Task WaitForExitAsync() => Task.CompletedTask;
             public void Dispose() { }
         }
@@ -440,5 +448,31 @@ public class ProgramHandlerTests : IDisposable
         var code = await Run("run", "--output", outDir, "--state", "OH");
         Assert.Equal(0, code);
         Assert.NotNull(_runner.StartInfo);
+    }
+
+    [Fact]
+    public async Task JavaProcess_NonZeroExit_PropagatesExitCode()
+    {
+        // (C6) When the spawned java process exits non-zero, the CLI must
+        // propagate that exact exit code — not coerce to 0, and not 1 or 3
+        // unless it actually came from java.
+        _runner.ExitCode = 137;
+        _runner.StderrText = "totally unfamiliar error\n";
+        var outDir = Path.Combine(_tempDir, "out-nonzero-exit");
+        var code = await Run("run", "--output", outDir, "--state", "OH");
+        Assert.Equal(137, code);
+    }
+
+    [Fact]
+    public async Task JavaProcess_NonZeroExit_WithRecognizedStderr_StillReturnsJavasExitCode()
+    {
+        // (C6) Hint printing must not change the exit code we return. The
+        // user-visible hint is a stderr decoration; the contract is the exit
+        // code.
+        _runner.ExitCode = 1;
+        _runner.StderrText = "java.lang.RuntimeException: Unable to select a random city id for state Zoo\n";
+        var outDir = Path.Combine(_tempDir, "out-nonzero-hint");
+        var code = await Run("run", "--output", outDir, "--state", "OH");
+        Assert.Equal(1, code);
     }
 }

--- a/tests/Synthea.Cli.UnitTests/SyntheaErrorPatternsTests.cs
+++ b/tests/Synthea.Cli.UnitTests/SyntheaErrorPatternsTests.cs
@@ -1,0 +1,77 @@
+using Synthea.Cli;
+using Xunit;
+
+namespace Synthea.Cli.UnitTests;
+
+public class SyntheaErrorPatternsTests
+{
+    [Fact]
+    public void TryGetRemediation_UnknownState_ReturnsGeographyHint()
+    {
+        var stderr = "java.lang.RuntimeException: Unable to select a random city id for state Zoo\n  at App.run(App.java:42)";
+        var hint = SyntheaErrorPatterns.TryGetRemediation(stderr);
+        Assert.NotNull(hint);
+        Assert.Contains("geography", hint, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryGetRemediation_Oom_ReturnsHeapHint()
+    {
+        var stderr = "Exception in thread \"main\" java.lang.OutOfMemoryError: Java heap space";
+        var hint = SyntheaErrorPatterns.TryGetRemediation(stderr);
+        Assert.NotNull(hint);
+        Assert.Contains("heap", hint, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryGetRemediation_OldJava_ReturnsJavaUpgradeHint()
+    {
+        var stderr = "Error: LinkageError occurred while loading main class App\n  java.lang.UnsupportedClassVersionError: App has been compiled by a more recent version";
+        var hint = SyntheaErrorPatterns.TryGetRemediation(stderr);
+        Assert.NotNull(hint);
+        Assert.Contains("Java", hint);
+    }
+
+    [Fact]
+    public void TryGetRemediation_NoClassDefFound_ReturnsCorruptJarHint()
+    {
+        var stderr = "Exception in thread \"main\" java.lang.NoClassDefFoundError: org/mitre/synthea/X";
+        var hint = SyntheaErrorPatterns.TryGetRemediation(stderr);
+        Assert.NotNull(hint);
+        Assert.Contains("cache clear", hint, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryGetRemediation_FileNotFound_ReturnsInputPathsHint()
+    {
+        var stderr = "Caused by: java.io.FileNotFoundException: /not/here.json";
+        var hint = SyntheaErrorPatterns.TryGetRemediation(stderr);
+        Assert.NotNull(hint);
+        Assert.Contains("--module", hint);
+    }
+
+    [Fact]
+    public void TryGetRemediation_UnknownError_ReturnsNull()
+    {
+        var stderr = "java.lang.NullPointerException: \"this.x\" is null because this.thing is null";
+        var hint = SyntheaErrorPatterns.TryGetRemediation(stderr);
+        Assert.Null(hint);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void TryGetRemediation_EmptyOrNull_ReturnsNull(string? stderr)
+    {
+        var hint = SyntheaErrorPatterns.TryGetRemediation(stderr);
+        Assert.Null(hint);
+    }
+
+    [Fact]
+    public void TryGetRemediation_Match_IsCaseInsensitive()
+    {
+        var stderr = "exception in thread main java.lang.outofmemoryerror: heap";
+        var hint = SyntheaErrorPatterns.TryGetRemediation(stderr);
+        Assert.NotNull(hint);
+    }
+}


### PR DESCRIPTION
## Summary
- New \`ProcessHelpers.RelayAndCapture\` keeps the live stderr relay AND retains the last 50 lines in a bounded ring buffer.
- New \`SyntheaErrorPatterns\` table maps known Synthea error substrings (state geography, OOM, UnsupportedClassVersionError, NoClassDefFoundError, FileNotFoundException, ...) to a one-line remediation hint.
- \`RunCommand\` consults the table on non-zero java exits and prints \`hint: ...\` after the existing stderr output. Exit code is whatever java returned — the hint is decoration, not a contract change.

Implements v-next **C6**.

## Test plan
- [x] 8 SyntheaErrorPatterns tests (state, OOM, UnsupportedClassVersion, NoClassDefFound, FileNotFound, unknown, null/empty, case-insensitive)
- [x] Non-zero java exit propagates exact exit code (137 → 137)
- [x] Non-zero java exit with recognized stderr still returns java's exit code (1 → 1)
- [x] All existing tests still pass
- [x] \`dotnet build\` clean | 132 unit tests pass | \`dotnet format\` clean