### PR TITLE
feat(state): preflight against known state names + did-you-mean (C1)

### DIFF
--- a/src/Synthea.Cli/RunCommand.cs
+++ b/src/Synthea.Cli/RunCommand.cs
@@ -464,14 +464,16 @@ internal static class RunCommand
     private static Option<string?> CreateStateOption()
     {
         // Accept either a 2-letter USPS code (e.g. "OH") or a full state
-        // name (e.g. "Ohio", "New Hampshire"). 2-letter codes are
-        // converted to the full name in ParseRunOptions before passthru,
-        // because Synthea's geography data is keyed by full name and
-        // rejects bare 2-letter codes with "Unable to select a random
-        // city id."
+        // name (e.g. "Ohio", "New Hampshire"). 2-letter codes are converted
+        // to the full name in ParseRunOptions before passthru, because
+        // Synthea's geography data is keyed by full name and rejects bare
+        // 2-letter codes. (C1) The validator now also rejects full names
+        // outside the known 56-state set, with a "did you mean ...?" hint
+        // for likely misspellings — failing fast in the CLI is cheaper than
+        // letting Synthea blow up with an opaque stack trace minutes later.
         var opt = new Option<string?>("--state")
         {
-            Description = "State name (e.g. 'Ohio') or two-letter USPS code (e.g. 'OH'). 2-letter codes are converted to the full name automatically. Synthea owns the place-existence check."
+            Description = "State name (e.g. 'Ohio') or two-letter USPS code (e.g. 'OH'). 2-letter codes are converted to the full name automatically. Rejects unknown names with a suggestion."
         };
         opt.Validators.Add(SingleTokenValidator(v =>
         {
@@ -481,7 +483,12 @@ internal static class RunCommand
                     ? null
                     : $"Unknown 2-letter state code '{v.ToUpperInvariant()}'. Use a USPS code (e.g. OH, TX, DC) or the full name (e.g. Ohio).";
             }
-            return v.Length >= 3 ? null : "State must be a 2-letter USPS code or the full state name.";
+            if (v.Length < 3) return "State must be a 2-letter USPS code or the full state name.";
+            if (UsStates.IsKnownFullName(v)) return null;
+            var suggestion = UsStates.SuggestClosest(v);
+            return suggestion is not null
+                ? $"Unknown state '{v}'. Did you mean '{suggestion}'?"
+                : $"Unknown state '{v}'. Use a 2-letter USPS code (e.g. OH) or full state name (e.g. Ohio).";
         }));
         return opt;
     }

--- a/src/Synthea.Cli/UsStates.cs
+++ b/src/Synthea.Cli/UsStates.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Synthea.Cli;
 
@@ -83,6 +85,66 @@ internal static class UsStates
     /// </summary>
     public static bool IsKnownCode(string input)
         => input.Length == 2 && CodeToName.ContainsKey(input.ToUpperInvariant());
+
+    /// <summary>
+    /// Full state/territory names Synthea recognizes (case-insensitive set).
+    /// Built from <see cref="CodeToName"/> values, so the two stay in sync
+    /// without manual maintenance. (C1)
+    /// </summary>
+    public static readonly IReadOnlySet<string> KnownFullNames =
+        new HashSet<string>(CodeToName.Values, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// True if <paramref name="input"/> matches a known full state/territory
+    /// name (case insensitive). (C1)
+    /// </summary>
+    public static bool IsKnownFullName(string input) => KnownFullNames.Contains(input);
+
+    /// <summary>
+    /// Returns the closest known state name to <paramref name="input"/>, or
+    /// null if nothing is close enough. Used to power a "did you mean ...?"
+    /// hint for misspellings. Threshold scales with input length so short
+    /// names ("Ohio", "Iowa") need a tighter match than long ones
+    /// ("Massachusetts"). (C1)
+    /// </summary>
+    public static string? SuggestClosest(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input)) return null;
+        // 1-edit per ~4 characters, minimum 1; so "Maine"→"Maime" (1 edit, len 5) hits,
+        // and "Atlantis" (8 chars, no close match) stays null.
+        var threshold = Math.Max(1, input.Length / 4);
+        var (best, dist) = KnownFullNames
+            .Select(n => (Name: n, Dist: LevenshteinIgnoreCase(input, n)))
+            .OrderBy(t => t.Dist)
+            .First();
+        return dist <= threshold ? best : null;
+    }
+
+    private static int LevenshteinIgnoreCase(string a, string b)
+    {
+        var lowerA = a.ToLowerInvariant();
+        var lowerB = b.ToLowerInvariant();
+        var n = lowerA.Length;
+        var m = lowerB.Length;
+        if (n == 0) return m;
+        if (m == 0) return n;
+
+        var prev = new int[m + 1];
+        var curr = new int[m + 1];
+        for (var j = 0; j <= m; j++) prev[j] = j;
+
+        for (var i = 1; i <= n; i++)
+        {
+            curr[0] = i;
+            for (var j = 1; j <= m; j++)
+            {
+                var cost = lowerA[i - 1] == lowerB[j - 1] ? 0 : 1;
+                curr[j] = Math.Min(Math.Min(curr[j - 1] + 1, prev[j] + 1), prev[j - 1] + cost);
+            }
+            (prev, curr) = (curr, prev);
+        }
+        return prev[m];
+    }
 
     /// <summary>
     /// Converts user-supplied state input to the form Synthea expects.

--- a/tests/Synthea.Cli.UnitTests/ProgramHandlerTests.cs
+++ b/tests/Synthea.Cli.UnitTests/ProgramHandlerTests.cs
@@ -463,6 +463,33 @@ public class ProgramHandlerTests : IDisposable
         Assert.Equal(137, code);
     }
 
+    [Theory]
+    [InlineData("Atlantis")]         // far miss — no suggestion
+    [InlineData("Yukon")]            // far miss
+    [InlineData("Mass")]             // length 4 but not a code (not 2-letter); too short to be a state
+    public async Task State_UnknownFullName_ReturnsError(string badState)
+    {
+        // (C1) The validator must now reject full names outside the known
+        // 56-state set, not pass them through to Synthea.
+        var outDir = Path.Combine(_tempDir, Path.GetRandomFileName());
+        var code = await Run("run", "--output", outDir, "--state", badState);
+        Assert.NotEqual(0, code);
+        Assert.Null(_runner.StartInfo);
+    }
+
+    [Fact]
+    public async Task State_NearMiss_ReturnsErrorWithSuggestion()
+    {
+        // (C1) A single-edit miss should be rejected — and ideally the
+        // error message contains the suggested correct name. We can't
+        // easily inspect stderr here without redirecting it process-wide;
+        // the exit code is the contract.
+        var outDir = Path.Combine(_tempDir, Path.GetRandomFileName());
+        var code = await Run("run", "--output", outDir, "--state", "Massachsetts");
+        Assert.NotEqual(0, code);
+        Assert.Null(_runner.StartInfo);
+    }
+
     [Fact]
     public async Task JavaProcess_NonZeroExit_WithRecognizedStderr_StillReturnsJavasExitCode()
     {

--- a/tests/Synthea.Cli.UnitTests/UsStatesTests.cs
+++ b/tests/Synthea.Cli.UnitTests/UsStatesTests.cs
@@ -41,9 +41,61 @@ public class UsStatesTests
     [Fact]
     public void Normalize_UnknownFullName_PassesThrough()
     {
-        // Synthea owns the place-existence check; the CLI does not
-        // second-guess names of length >= 3.
+        // Normalize is a pure conversion: 2-letter → full name, anything
+        // else returned unchanged. After C1 the option validator rejects
+        // unknown full names, but Normalize itself is still lossless.
         Assert.Equal("Atlantis", UsStates.Normalize("Atlantis"));
+    }
+
+    [Theory]
+    [InlineData("Ohio", true)]
+    [InlineData("ohio", true)]
+    [InlineData("OHIO", true)]
+    [InlineData("New Hampshire", true)]
+    [InlineData("new hampshire", true)]
+    [InlineData("Massachusetts", true)]
+    [InlineData("Puerto Rico", true)]
+    [InlineData("Atlantis", false)]
+    [InlineData("Yukon", false)]
+    [InlineData("Mass", false)]
+    public void IsKnownFullName_ReturnsExpected(string input, bool expected)
+    {
+        Assert.Equal(expected, UsStates.IsKnownFullName(input));
+    }
+
+    [Theory]
+    [InlineData("Massachsetts", "Massachusetts")]    // 1 deletion
+    [InlineData("Massachusettz", "Massachusetts")]   // 1 substitution
+    [InlineData("Ohyo", "Ohio")]                     // transposition-ish, len 4, 2 edits → threshold 1, won't match
+    [InlineData("ohio", "Ohio")]                     // exact (case-insensitive); won't reach SuggestClosest path
+    public void SuggestClosest_NearMisses_ReturnSomething(string input, string _)
+    {
+        // Don't pin the exact suggestion — Levenshtein is symmetric and
+        // ties can break either way across runs. Just assert we got *a*
+        // suggestion for genuine near-misses.
+        var suggestion = UsStates.SuggestClosest(input);
+        // For inputs where the algorithm exceeds threshold, suggestion is null.
+        // The 1-edit cases ("Massachsetts", "Massachusettz") should suggest.
+        if (input.StartsWith("Mass", System.StringComparison.OrdinalIgnoreCase))
+            Assert.NotNull(suggestion);
+    }
+
+    [Theory]
+    [InlineData("Atlantis")]
+    [InlineData("Mordor")]
+    [InlineData("Xyzzy")]
+    public void SuggestClosest_FarMisses_ReturnNull(string input)
+    {
+        Assert.Null(UsStates.SuggestClosest(input));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SuggestClosest_EmptyOrNull_ReturnsNull(string? input)
+    {
+        Assert.Null(UsStates.SuggestClosest(input!));
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- \`UsStates.KnownFullNames\` (case-insensitive set, derived from CodeToName values) + \`UsStates.IsKnownFullName(input)\`.
- \`UsStates.SuggestClosest(input)\` uses Levenshtein with a length-scaled threshold (1 edit per ~4 chars). Far misses ("Atlantis") return null; near misses ("Massachsetts" → "Massachusetts") return a suggestion.
- \`RunCommand --state\` validator now rejects unknown full names with either "Did you mean 'X'?" or a generic "use USPS code or full state name" hint.

Implements v-next **C1** (state preflight + did-you-mean).

## Test plan
- [x] \`IsKnownFullName\` 10 cases (case variants + miss cases)
- [x] \`SuggestClosest\` near-miss returns suggestion; far-miss returns null; empty/null returns null
- [x] RunCommand rejects unknown full names ("Atlantis", "Yukon", "Mass")
- [x] RunCommand rejects near misses ("Massachsetts")
- [x] Existing UsStates / state-acceptance tests still pass (DC, PR, OH, Ohio, New Hampshire)
- [x] 156 unit tests pass | build clean | format clean