### PR TITLE
feat(run): add reproducibility + overflow flags (A1, A2, A3)

### DIFF
--- a/src/Synthea.Cli/RunCommand.cs
+++ b/src/Synthea.Cli/RunCommand.cs
@@ -60,6 +60,19 @@ internal static class RunCommand
         {
             Description = "Fail the run if the upstream release does not publish a .sha256 asset."
         };
+        var referenceDateOpt = CreateReferenceDateOption();   // A1
+        var endDateOpt = CreateEndDateOption();               // A1
+        var allowFutureEndOpt = new Option<bool>("--allow-future-end")
+        {
+            Description = "Permit --end-date beyond today (Synthea -E)."
+        };
+        var clinicianSeedOpt = CreateClinicianSeedOption();   // A1
+        var singlePersonSeedOpt = CreateSinglePersonSeedOption(); // A1
+        var overflowOpt = new Option<bool>("--overflow")
+        {
+            Description = "Allow Synthea's overflow generation (-o true). " +
+                          "Off by default; turn on for full-fidelity reruns of past results."
+        };
         var passthru = CreatePassthruArgument();
 
         runCmd.Options.Add(outputOpt);
@@ -82,6 +95,12 @@ internal static class RunCommand
         runCmd.Options.Add(printArgsOpt);
         runCmd.Options.Add(jarOpt);
         runCmd.Options.Add(insistChecksumOpt);
+        runCmd.Options.Add(referenceDateOpt);
+        runCmd.Options.Add(endDateOpt);
+        runCmd.Options.Add(allowFutureEndOpt);
+        runCmd.Options.Add(clinicianSeedOpt);
+        runCmd.Options.Add(singlePersonSeedOpt);
+        runCmd.Options.Add(overflowOpt);
         runCmd.Arguments.Add(passthru);
 
         runCmd.TreatUnmatchedTokensAsErrors = false;
@@ -91,7 +110,8 @@ internal static class RunCommand
             var (hosting, args) = ParseRunOptions(parseResult, refreshOpt, javaOpt, outputOpt, stateOpt, cityOpt,
                 genderOpt, ageOpt, moduleDirOpt, moduleOpt, popOpt, seedOpt, configOpt, zipOpt,
                 fhirVerOpt, initialSnapOpt, updatedSnapOpt, daysForwardOpt, formatOpt, addFormatOpt,
-                jarOpt, insistChecksumOpt, passthru);
+                jarOpt, insistChecksumOpt, passthru,
+                referenceDateOpt, endDateOpt, allowFutureEndOpt, clinicianSeedOpt, singlePersonSeedOpt, overflowOpt);
             var printArgs = parseResult.GetValue(printArgsOpt);
 
             // C7: malformed ~/.synthea-cli/config.json must fail the run with
@@ -277,6 +297,38 @@ internal static class RunCommand
             argList.Add("-t");
             argList.Add(o.DaysForward.Value.ToString());
         }
+        // A1: reproducibility flags. Convert ISO YYYY-MM-DD → YYYYMMDD,
+        // which is the form Synthea's date parser expects.
+        if (!string.IsNullOrWhiteSpace(o.ReferenceDate))
+        {
+            argList.Add("-r");
+            argList.Add(o.ReferenceDate!.Replace("-", string.Empty));
+        }
+        if (!string.IsNullOrWhiteSpace(o.EndDate))
+        {
+            argList.Add("-e");
+            argList.Add(o.EndDate!.Replace("-", string.Empty));
+        }
+        if (o.AllowFutureEnd)
+        {
+            argList.Add("-E");
+        }
+        if (o.ClinicianSeed.HasValue)
+        {
+            argList.Add("-cs");
+            argList.Add(o.ClinicianSeed.Value.ToString());
+        }
+        if (o.SinglePersonSeed.HasValue)
+        {
+            argList.Add("-ps");
+            argList.Add(o.SinglePersonSeed.Value.ToString());
+        }
+        // A2/A3: overflow. Synthea -o true vs false; off by default.
+        if (o.Overflow)
+        {
+            argList.Add("-o");
+            argList.Add("true");
+        }
         if (!string.IsNullOrWhiteSpace(o.FhirVersion))
         {
             argList.Add("--exporter.fhir.version=" + o.FhirVersion!.ToUpperInvariant());
@@ -386,7 +438,13 @@ internal static class RunCommand
         Option<string[]> addFormatOpt,
         Option<string?> jarOpt,
         Option<bool> insistChecksumOpt,
-        Argument<string[]> passthru)
+        Argument<string[]> passthru,
+        Option<string?> referenceDateOpt,
+        Option<string?> endDateOpt,
+        Option<bool> allowFutureEndOpt,
+        Option<int?> clinicianSeedOpt,
+        Option<int?> singlePersonSeedOpt,
+        Option<bool> overflowOpt)
     {
         var javaPathArg = parseResult.GetValue(javaOpt);
         var hosting = new HostingOptions(
@@ -412,7 +470,13 @@ internal static class RunCommand
             DaysForward: parseResult.GetValue(daysOpt),
             Formats: parseResult.GetValue(formatOpt) ?? Array.Empty<string>(),
             AdditionalFormats: parseResult.GetValue(addFormatOpt) ?? Array.Empty<string>(),
-            Passthru: parseResult.GetValue(passthru) ?? Array.Empty<string>());
+            Passthru: parseResult.GetValue(passthru) ?? Array.Empty<string>(),
+            ReferenceDate: parseResult.GetValue(referenceDateOpt),
+            EndDate: parseResult.GetValue(endDateOpt),
+            AllowFutureEnd: parseResult.GetValue(allowFutureEndOpt),
+            ClinicianSeed: parseResult.GetValue(clinicianSeedOpt),
+            SinglePersonSeed: parseResult.GetValue(singlePersonSeedOpt),
+            Overflow: parseResult.GetValue(overflowOpt));
         return (hosting, args);
     }
 
@@ -652,4 +716,59 @@ internal static class RunCommand
         Arity = ArgumentArity.ZeroOrMore,
         Description = "Any other arguments forwarded unchanged to synthea.jar"
     };
+
+    // A1: reproducibility window — accepts ISO YYYY-MM-DD; emitted to
+    // Synthea as YYYYMMDD (its accepted form) by BuildArgumentList.
+    private static Option<string?> CreateReferenceDateOption()
+    {
+        var opt = new Option<string?>("--reference-date")
+        {
+            Description = "Reference date (ISO YYYY-MM-DD). Maps to Synthea -r YYYYMMDD."
+        };
+        opt.Validators.Add(SingleTokenValidator(ValidateIsoDate));
+        return opt;
+    }
+
+    private static Option<string?> CreateEndDateOption()
+    {
+        var opt = new Option<string?>("--end-date")
+        {
+            Description = "Simulation end date (ISO YYYY-MM-DD). Maps to Synthea -e YYYYMMDD. " +
+                          "Requires --allow-future-end if the date is beyond today."
+        };
+        opt.Validators.Add(SingleTokenValidator(ValidateIsoDate));
+        return opt;
+    }
+
+    private static Option<int?> CreateClinicianSeedOption()
+    {
+        var opt = new Option<int?>("--clinician-seed")
+        {
+            Description = "Random seed for clinician generation (Synthea -cs N)."
+        };
+        opt.Validators.Add(SingleTokenValidator(v =>
+            int.TryParse(v, out _) ? null : "Clinician seed must be an integer."));
+        return opt;
+    }
+
+    private static Option<int?> CreateSinglePersonSeedOption()
+    {
+        var opt = new Option<int?>("--single-person-seed")
+        {
+            Description = "Random seed for single-person generation (Synthea -ps N)."
+        };
+        opt.Validators.Add(SingleTokenValidator(v =>
+            int.TryParse(v, out _) ? null : "Single-person seed must be an integer."));
+        return opt;
+    }
+
+    // ISO-8601 calendar date (YYYY-MM-DD), strict. Bare-yyyy / yyyy-mm
+    // shortcuts not accepted — Synthea wants full date precision and we
+    // don't want to silently coerce.
+    private static string? ValidateIsoDate(string v)
+        => DateTime.TryParseExact(v, "yyyy-MM-dd",
+                                  System.Globalization.CultureInfo.InvariantCulture,
+                                  System.Globalization.DateTimeStyles.None, out _)
+            ? null
+            : $"Date must be ISO YYYY-MM-DD (got '{v}').";
 }

--- a/src/Synthea.Cli/SyntheaArgs.cs
+++ b/src/Synthea.Cli/SyntheaArgs.cs
@@ -3,6 +3,9 @@ namespace Synthea.Cli;
 // Everything that maps to flags or positional values Synthea itself
 // consumes. BuildArgumentList depends only on this; nothing about
 // hosting (java path, output dir, refresh) belongs here.
+//
+// New fields go at the end with defaults so existing positional-arg
+// callers in tests don't all need updating each phase.
 internal record SyntheaArgs(
     string? State,
     string? City,
@@ -20,4 +23,13 @@ internal record SyntheaArgs(
     int? DaysForward,
     string[] Formats,
     string[] AdditionalFormats,
-    string[] Passthru);
+    string[] Passthru,
+    // Phase 5 (A1+A2+A3): reproducibility flags accept ISO YYYY-MM-DD;
+    // BuildArgumentList converts to Synthea's YYYYMMDD form. -E permits
+    // EndDate beyond today; -o true enables overflow generation.
+    string? ReferenceDate = null,
+    string? EndDate = null,
+    bool AllowFutureEnd = false,
+    int? ClinicianSeed = null,
+    int? SinglePersonSeed = null,
+    bool Overflow = false);

--- a/tests/Synthea.Cli.UnitTests/ProgramHandlerTests.cs
+++ b/tests/Synthea.Cli.UnitTests/ProgramHandlerTests.cs
@@ -463,6 +463,116 @@ public class ProgramHandlerTests : IDisposable
         Assert.Equal(137, code);
     }
 
+    // A1+A2+A3 (Phase 5): reproducibility + overflow flag parsing.
+
+    [Fact]
+    public async Task ReferenceDate_Iso_ConvertedToYyyymmdd()
+    {
+        var outDir = Path.Combine(_tempDir, "out-refdate");
+        var code = await Run("run", "--output", outDir, "--reference-date", "2024-03-15");
+        Assert.Equal(0, code);
+        var list = _runner.StartInfo!.ArgumentList;
+        Assert.Contains("-r", list);
+        Assert.Contains("20240315", list);
+    }
+
+    [Fact]
+    public async Task ReferenceDate_BadFormat_RejectedByValidator()
+    {
+        var outDir = Path.Combine(_tempDir, "out-refdate-bad");
+        var code = await Run("run", "--output", outDir, "--reference-date", "03/15/2024");
+        Assert.NotEqual(0, code);
+        Assert.Null(_runner.StartInfo);
+    }
+
+    [Fact]
+    public async Task EndDate_Iso_ConvertedToYyyymmdd()
+    {
+        var outDir = Path.Combine(_tempDir, "out-enddate");
+        var code = await Run("run", "--output", outDir, "--end-date", "2030-12-31");
+        Assert.Equal(0, code);
+        var list = _runner.StartInfo!.ArgumentList;
+        Assert.Contains("-e", list);
+        Assert.Contains("20301231", list);
+    }
+
+    [Fact]
+    public async Task AllowFutureEnd_EmitsDashE()
+    {
+        var outDir = Path.Combine(_tempDir, "out-future-end");
+        var code = await Run("run", "--output", outDir, "--allow-future-end");
+        Assert.Equal(0, code);
+        Assert.Contains("-E", _runner.StartInfo!.ArgumentList);
+    }
+
+    [Fact]
+    public async Task ClinicianSeed_EmitsDashCs()
+    {
+        var outDir = Path.Combine(_tempDir, "out-cs");
+        var code = await Run("run", "--output", outDir, "--clinician-seed", "42");
+        Assert.Equal(0, code);
+        var list = _runner.StartInfo!.ArgumentList;
+        Assert.Contains("-cs", list);
+        Assert.Contains("42", list);
+    }
+
+    [Fact]
+    public async Task SinglePersonSeed_EmitsDashPs()
+    {
+        var outDir = Path.Combine(_tempDir, "out-ps");
+        var code = await Run("run", "--output", outDir, "--single-person-seed", "7");
+        Assert.Equal(0, code);
+        var list = _runner.StartInfo!.ArgumentList;
+        Assert.Contains("-ps", list);
+        Assert.Contains("7", list);
+    }
+
+    [Fact]
+    public async Task ClinicianSeed_NonInteger_Rejected()
+    {
+        var outDir = Path.Combine(_tempDir, "out-cs-bad");
+        var code = await Run("run", "--output", outDir, "--clinician-seed", "oops");
+        Assert.NotEqual(0, code);
+        Assert.Null(_runner.StartInfo);
+    }
+
+    [Fact]
+    public async Task Overflow_EmitsDashOTrue()
+    {
+        var outDir = Path.Combine(_tempDir, "out-overflow");
+        var code = await Run("run", "--output", outDir, "--overflow");
+        Assert.Equal(0, code);
+        var list = _runner.StartInfo!.ArgumentList;
+        // -o true comes BEFORE any positional state/city/zip in BuildArgumentList.
+        var oIdx = list.IndexOf("-o");
+        Assert.True(oIdx >= 0, "expected -o in arg list");
+        Assert.Equal("true", list[oIdx + 1]);
+    }
+
+    [Fact]
+    public async Task AllReproFlags_AppearTogether()
+    {
+        var outDir = Path.Combine(_tempDir, "out-all-repro");
+        var code = await Run(
+            "run", "--output", outDir,
+            "--reference-date", "2024-01-01",
+            "--end-date", "2024-12-31",
+            "--allow-future-end",
+            "--clinician-seed", "1",
+            "--single-person-seed", "2",
+            "--overflow");
+        Assert.Equal(0, code);
+        var list = _runner.StartInfo!.ArgumentList;
+        Assert.Contains("-r", list);
+        Assert.Contains("20240101", list);
+        Assert.Contains("-e", list);
+        Assert.Contains("20241231", list);
+        Assert.Contains("-E", list);
+        Assert.Contains("-cs", list);
+        Assert.Contains("-ps", list);
+        Assert.Contains("-o", list);
+    }
+
     [Theory]
     [InlineData("Atlantis")]         // far miss — no suggestion
     [InlineData("Yukon")]            // far miss


### PR DESCRIPTION
## Summary
Six new options for reproducibility & overflow control:

| Flag | Synthea form |
|------|--------------|
| \`--reference-date YYYY-MM-DD\` | \`-r YYYYMMDD\` |
| \`--end-date YYYY-MM-DD\` | \`-e YYYYMMDD\` |
| \`--allow-future-end\` | \`-E\` |
| \`--clinician-seed N\` | \`-cs N\` |
| \`--single-person-seed N\` | \`-ps N\` |
| \`--overflow\` | \`-o true\` |

ISO dates are converted to Synthea's YYYYMMDD form by BuildArgumentList. Seeds validate as integers; bad inputs reject before java launches.

Closes v-next **A1**, **A2**, **A3**.

## Test plan
- [x] Each flag emits expected Synthea arg (\`-r\`, \`-e\`, \`-E\`, \`-cs\`, \`-ps\`, \`-o\`)
- [x] Bad date format rejected (\`03/15/2024\` → CLI error, no run)
- [x] Non-integer seed rejected
- [x] All six flags together produce the right combined arg list
- [x] 165 unit tests pass | build clean | format clean