### PR TITLE
feat(run): --property KEY=VALUE for arbitrary Synthea properties (A6)

### DIFF
--- a/src/Synthea.Cli/RunCommand.cs
+++ b/src/Synthea.Cli/RunCommand.cs
@@ -73,6 +73,7 @@ internal static class RunCommand
             Description = "Allow Synthea's overflow generation (-o true). " +
                           "Off by default; turn on for full-fidelity reruns of past results."
         };
+        var propertyOpt = CreatePropertyOption();                 // A6
         var passthru = CreatePassthruArgument();
 
         runCmd.Options.Add(outputOpt);
@@ -101,6 +102,7 @@ internal static class RunCommand
         runCmd.Options.Add(clinicianSeedOpt);
         runCmd.Options.Add(singlePersonSeedOpt);
         runCmd.Options.Add(overflowOpt);
+        runCmd.Options.Add(propertyOpt);
         runCmd.Arguments.Add(passthru);
 
         runCmd.TreatUnmatchedTokensAsErrors = false;
@@ -111,7 +113,8 @@ internal static class RunCommand
                 genderOpt, ageOpt, moduleDirOpt, moduleOpt, popOpt, seedOpt, configOpt, zipOpt,
                 fhirVerOpt, initialSnapOpt, updatedSnapOpt, daysForwardOpt, formatOpt, addFormatOpt,
                 jarOpt, insistChecksumOpt, passthru,
-                referenceDateOpt, endDateOpt, allowFutureEndOpt, clinicianSeedOpt, singlePersonSeedOpt, overflowOpt);
+                referenceDateOpt, endDateOpt, allowFutureEndOpt, clinicianSeedOpt, singlePersonSeedOpt, overflowOpt,
+                propertyOpt);
             var printArgs = parseResult.GetValue(printArgsOpt);
 
             // C7: malformed ~/.synthea-cli/config.json must fail the run with
@@ -329,6 +332,16 @@ internal static class RunCommand
             argList.Add("-o");
             argList.Add("true");
         }
+        // A6: each --property KEY=VALUE becomes Synthea's documented
+        // `--KEY=VALUE` form. The validator on the option guarantees a
+        // single '=' and a well-formed key, so we don't re-check here.
+        if (o.Properties is not null)
+        {
+            foreach (var kv in o.Properties)
+            {
+                argList.Add("--" + kv);
+            }
+        }
         if (!string.IsNullOrWhiteSpace(o.FhirVersion))
         {
             argList.Add("--exporter.fhir.version=" + o.FhirVersion!.ToUpperInvariant());
@@ -444,7 +457,8 @@ internal static class RunCommand
         Option<bool> allowFutureEndOpt,
         Option<int?> clinicianSeedOpt,
         Option<int?> singlePersonSeedOpt,
-        Option<bool> overflowOpt)
+        Option<bool> overflowOpt,
+        Option<string[]> propertyOpt)
     {
         var javaPathArg = parseResult.GetValue(javaOpt);
         var hosting = new HostingOptions(
@@ -476,7 +490,8 @@ internal static class RunCommand
             AllowFutureEnd: parseResult.GetValue(allowFutureEndOpt),
             ClinicianSeed: parseResult.GetValue(clinicianSeedOpt),
             SinglePersonSeed: parseResult.GetValue(singlePersonSeedOpt),
-            Overflow: parseResult.GetValue(overflowOpt));
+            Overflow: parseResult.GetValue(overflowOpt),
+            Properties: parseResult.GetValue(propertyOpt));
         return (hosting, args);
     }
 
@@ -760,6 +775,39 @@ internal static class RunCommand
         opt.Validators.Add(SingleTokenValidator(v =>
             int.TryParse(v, out _) ? null : "Single-person seed must be an integer."));
         return opt;
+    }
+
+    // A6: --property KEY=VALUE, repeatable. Lets callers pass any Synthea
+    // property we haven't surfaced as a first-class flag without dropping
+    // into the bare passthru argument tail.
+    private static readonly Regex PropertyKeyRegex =
+        new("^[a-zA-Z][a-zA-Z0-9._-]*$", RegexOptions.Compiled);
+
+    private static Option<string[]> CreatePropertyOption()
+    {
+        var opt = new Option<string[]>("--property")
+        {
+            Description = "Set a Synthea property as KEY=VALUE (repeatable). " +
+                          "Emitted as --KEY=VALUE. Use for properties without a first-class flag.",
+            Arity = ArgumentArity.ZeroOrMore
+        };
+        opt.Validators.Add(MultiTokenValidator(ValidateProperty));
+        return opt;
+    }
+
+    internal static string? ValidateProperty(string v)
+    {
+        if (string.IsNullOrEmpty(v))
+            return "Property must be KEY=VALUE.";
+        var eq = v.IndexOf('=');
+        if (eq < 0)
+            return $"Property '{v}' must be KEY=VALUE.";
+        if (v.IndexOf('=', eq + 1) >= 0)
+            return $"Property '{v}' must contain exactly one '=' (KEY=VALUE).";
+        var key = v.Substring(0, eq);
+        if (!PropertyKeyRegex.IsMatch(key))
+            return $"Property key '{key}' must match [a-zA-Z][a-zA-Z0-9._-]*.";
+        return null;
     }
 
     // ISO-8601 calendar date (YYYY-MM-DD), strict. Bare-yyyy / yyyy-mm

--- a/src/Synthea.Cli/SyntheaArgs.cs
+++ b/src/Synthea.Cli/SyntheaArgs.cs
@@ -32,4 +32,8 @@ internal record SyntheaArgs(
     bool AllowFutureEnd = false,
     int? ClinicianSeed = null,
     int? SinglePersonSeed = null,
-    bool Overflow = false);
+    bool Overflow = false,
+    // Phase 6 (A6): repeatable --property KEY=VALUE pairs, emitted to
+    // Synthea as `--KEY=VALUE`. Lets callers reach any Synthea property
+    // we haven't surfaced as a first-class flag.
+    string[]? Properties = null);

--- a/tests/Synthea.Cli.UnitTests/ProgramRefactorTests.cs
+++ b/tests/Synthea.Cli.UnitTests/ProgramRefactorTests.cs
@@ -177,6 +177,54 @@ public class ProgramRefactorTests
     }
 
     [Fact]
+    public void BuildArgumentList_Properties_EmittedAsDoubleDashFlags()
+    {
+        // (A6) Each --property KEY=VALUE becomes the documented Synthea
+        // form `--KEY=VALUE`. Ordering: must come before positional state.
+        var args = new SyntheaArgs(
+            State: "OH", City: null, Gender: null, AgeRange: null,
+            ModuleDir: null, Modules: null, Population: null, Seed: null,
+            Config: null, Zip: null, FhirVersion: null,
+            InitialSnapshot: null, UpdatedSnapshot: null, DaysForward: null,
+            Formats: System.Array.Empty<string>(),
+            AdditionalFormats: System.Array.Empty<string>(),
+            Passthru: System.Array.Empty<string>(),
+            Properties: new[] { "generate.timestep=86400000", "exporter.json.export=true" });
+
+        var list = RunCommand.BuildArgumentList(args);
+        Assert.Contains("--generate.timestep=86400000", list);
+        Assert.Contains("--exporter.json.export=true", list);
+        var stateIdx = list.IndexOf("OH");
+        var propIdx = list.IndexOf("--generate.timestep=86400000");
+        Assert.True(propIdx < stateIdx,
+            $"properties (idx {propIdx}) should precede positional state (idx {stateIdx})");
+    }
+
+    [Theory]
+    [InlineData("key=value", null)]                          // happy
+    [InlineData("exporter.fhir.export=true", null)]          // dotted key
+    [InlineData("my-key=value", null)]                       // hyphen ok
+    [InlineData("my_key.sub=val", null)]                     // underscore + dot
+    [InlineData("nokey", "must be KEY=VALUE")]
+    [InlineData("=value", "must match")]
+    [InlineData("1bad=value", "must match")]
+    [InlineData("bad key=value", "must match")]
+    [InlineData("key=a=b", "exactly one")]
+    public void ValidateProperty_AppliesRules(string input, string? expectedFragment)
+    {
+        var err = RunCommand.ValidateProperty(input);
+        if (expectedFragment is null)
+        {
+            Assert.Null(err);
+        }
+        else
+        {
+            Assert.NotNull(err);
+            Assert.Contains(expectedFragment, err);
+        }
+    }
+
+    [Fact]
     public void CreateProcessStartInfo_UsesWorkingDirectoryAndJar()
     {
         var tmpDir = Path.Combine(Path.GetTempPath(), "synthea-test-tmp");


### PR DESCRIPTION
## Summary
- Adds repeatable `--property KEY=VALUE` option on `synthea run`
- Emits as Synthea's documented `--KEY=VALUE` form before positional state/city/zip
- Validator enforces single `=` separator and well-formed key (`[a-zA-Z][a-zA-Z0-9._-]*`)

## v-next ID
A6 — first-class passthrough for arbitrary Synthea properties without dropping into the bare `args` tail.

## Test plan
- [x] `BuildArgumentList_Properties_EmittedAsDoubleDashFlags` — verifies emission order and form
- [x] `ValidateProperty_AppliesRules` (theory) — happy paths + 4 failure modes (no `=`, empty key, leading digit, space in key, multiple `=`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)