### PR TITLE
feat(fhir): --us-core-version selection + --fhir-version R5 (A9, A10)

### DIFF
--- a/src/Synthea.Cli/RunCommand.cs
+++ b/src/Synthea.Cli/RunCommand.cs
@@ -74,6 +74,7 @@ internal static class RunCommand
                           "Off by default; turn on for full-fidelity reruns of past results."
         };
         var propertyOpt = CreatePropertyOption();                 // A6
+        var usCoreVerOpt = CreateUsCoreVersionOption();           // A9
         var passthru = CreatePassthruArgument();
 
         runCmd.Options.Add(outputOpt);
@@ -103,6 +104,7 @@ internal static class RunCommand
         runCmd.Options.Add(singlePersonSeedOpt);
         runCmd.Options.Add(overflowOpt);
         runCmd.Options.Add(propertyOpt);
+        runCmd.Options.Add(usCoreVerOpt);
         runCmd.Arguments.Add(passthru);
 
         runCmd.TreatUnmatchedTokensAsErrors = false;
@@ -114,7 +116,7 @@ internal static class RunCommand
                 fhirVerOpt, initialSnapOpt, updatedSnapOpt, daysForwardOpt, formatOpt, addFormatOpt,
                 jarOpt, insistChecksumOpt, passthru,
                 referenceDateOpt, endDateOpt, allowFutureEndOpt, clinicianSeedOpt, singlePersonSeedOpt, overflowOpt,
-                propertyOpt);
+                propertyOpt, usCoreVerOpt);
             var printArgs = parseResult.GetValue(printArgsOpt);
 
             // C7: malformed ~/.synthea-cli/config.json must fail the run with
@@ -346,6 +348,15 @@ internal static class RunCommand
         {
             argList.Add("--exporter.fhir.version=" + o.FhirVersion!.ToUpperInvariant());
         }
+        // (A9) US Core IG enable + version. Must precede the format-export
+        // block so Synthea reads the IG choice before deciding what to
+        // write. Validator on --us-core-version restricts to the published
+        // set, so we don't re-check the value here.
+        if (!string.IsNullOrWhiteSpace(o.UsCoreVersion))
+        {
+            argList.Add("--exporter.fhir.use_us_core_ig=true");
+            argList.Add($"--exporter.fhir.us_core_version={o.UsCoreVersion}");
+        }
         var formatPropertyMap = new Dictionary<string, string>
         {
             ["fhir"] = "exporter.fhir.export",
@@ -458,7 +469,8 @@ internal static class RunCommand
         Option<int?> clinicianSeedOpt,
         Option<int?> singlePersonSeedOpt,
         Option<bool> overflowOpt,
-        Option<string[]> propertyOpt)
+        Option<string[]> propertyOpt,
+        Option<string?> usCoreVerOpt)
     {
         var javaPathArg = parseResult.GetValue(javaOpt);
         var hosting = new HostingOptions(
@@ -491,7 +503,8 @@ internal static class RunCommand
             ClinicianSeed: parseResult.GetValue(clinicianSeedOpt),
             SinglePersonSeed: parseResult.GetValue(singlePersonSeedOpt),
             Overflow: parseResult.GetValue(overflowOpt),
-            Properties: parseResult.GetValue(propertyOpt));
+            Properties: parseResult.GetValue(propertyOpt),
+            UsCoreVersion: parseResult.GetValue(usCoreVerOpt));
         return (hosting, args);
     }
 
@@ -661,11 +674,14 @@ internal static class RunCommand
 
     private static Option<string?> CreateFhirVersionOption()
     {
-        var opt = new Option<string?>("--fhir-version") { Description = "FHIR version (R4 or STU3)" };
+        // (A10) R5 added to the allowlist. Synthea ≥ v4 supports R5
+        // exporters; older versions silently no-op. The CLI is permissive
+        // either way — Synthea is the source of truth for export support.
+        var opt = new Option<string?>("--fhir-version") { Description = "FHIR version (STU3, R4, or R5)" };
         opt.Validators.Add(SingleTokenValidator(v =>
         {
             var u = v.ToUpperInvariant();
-            return u == "R4" || u == "STU3" ? null : "FHIR version must be R4 or STU3.";
+            return u == "R4" || u == "STU3" || u == "R5" ? null : "FHIR version must be STU3, R4, or R5.";
         }));
         return opt;
     }
@@ -792,6 +808,26 @@ internal static class RunCommand
             Arity = ArgumentArity.ZeroOrMore
         };
         opt.Validators.Add(MultiTokenValidator(ValidateProperty));
+        return opt;
+    }
+
+    // A9: US Core IG version allowlist. The full set Synthea exposes via
+    // its `exporter.fhir.us_core_version` property as of v3.3+. New
+    // versions ship rarely; expanding the allowlist is a deliberate act.
+    internal static readonly string[] UsCoreVersions = { "3.1.1", "4", "5", "6", "7" };
+
+    private static Option<string?> CreateUsCoreVersionOption()
+    {
+        var opt = new Option<string?>("--us-core-version")
+        {
+            Description = "US Core IG version to apply to FHIR export. " +
+                          "Allowed: " + string.Join(", ", UsCoreVersions) + ". " +
+                          "Implies --exporter.fhir.use_us_core_ig=true."
+        };
+        opt.Validators.Add(SingleTokenValidator(v =>
+            Array.IndexOf(UsCoreVersions, v) >= 0
+                ? null
+                : $"US Core version must be one of: {string.Join(", ", UsCoreVersions)}."));
         return opt;
     }
 

--- a/src/Synthea.Cli/SyntheaArgs.cs
+++ b/src/Synthea.Cli/SyntheaArgs.cs
@@ -36,4 +36,9 @@ internal record SyntheaArgs(
     // Phase 6 (A6): repeatable --property KEY=VALUE pairs, emitted to
     // Synthea as `--KEY=VALUE`. Lets callers reach any Synthea property
     // we haven't surfaced as a first-class flag.
-    string[]? Properties = null);
+    string[]? Properties = null,
+    // Phase 7 (A9): US Core IG version. When set, BuildArgumentList emits
+    // BOTH --exporter.fhir.use_us_core_ig=true AND
+    // --exporter.fhir.us_core_version=N before any format-export lines, so
+    // Synthea picks up the IG before deciding what to write.
+    string? UsCoreVersion = null);

--- a/tests/Synthea.Cli.UnitTests/ProgramHandlerTests.cs
+++ b/tests/Synthea.Cli.UnitTests/ProgramHandlerTests.cs
@@ -600,6 +600,51 @@ public class ProgramHandlerTests : IDisposable
         Assert.Null(_runner.StartInfo);
     }
 
+    // A9+A10 (Phase 7): US Core version + FHIR R5.
+
+    [Theory]
+    [InlineData("3.1.1")]
+    [InlineData("4")]
+    [InlineData("5")]
+    [InlineData("6")]
+    [InlineData("7")]
+    public async Task UsCoreVersion_Allowed_EmitsBothProperties(string ver)
+    {
+        var outDir = Path.Combine(_tempDir, "out-uscore-" + ver);
+        var code = await Run("run", "--output", outDir, "--us-core-version", ver);
+        Assert.Equal(0, code);
+        var list = _runner.StartInfo!.ArgumentList;
+        Assert.Contains("--exporter.fhir.use_us_core_ig=true", list);
+        Assert.Contains($"--exporter.fhir.us_core_version={ver}", list);
+    }
+
+    [Fact]
+    public async Task UsCoreVersion_OutsideAllowlist_Rejected()
+    {
+        var outDir = Path.Combine(_tempDir, "out-uscore-bad");
+        var code = await Run("run", "--output", outDir, "--us-core-version", "99");
+        Assert.NotEqual(0, code);
+        Assert.Null(_runner.StartInfo);
+    }
+
+    [Fact]
+    public async Task FhirVersion_R5_Accepted()
+    {
+        var outDir = Path.Combine(_tempDir, "out-fhir-r5");
+        var code = await Run("run", "--output", outDir, "--fhir-version", "R5");
+        Assert.Equal(0, code);
+        Assert.Contains("--exporter.fhir.version=R5", _runner.StartInfo!.ArgumentList);
+    }
+
+    [Fact]
+    public async Task FhirVersion_Bogus_Rejected()
+    {
+        var outDir = Path.Combine(_tempDir, "out-fhir-bad");
+        var code = await Run("run", "--output", outDir, "--fhir-version", "R6");
+        Assert.NotEqual(0, code);
+        Assert.Null(_runner.StartInfo);
+    }
+
     [Fact]
     public async Task JavaProcess_NonZeroExit_WithRecognizedStderr_StillReturnsJavasExitCode()
     {

--- a/tests/Synthea.Cli.UnitTests/ProgramRefactorTests.cs
+++ b/tests/Synthea.Cli.UnitTests/ProgramRefactorTests.cs
@@ -225,6 +225,51 @@ public class ProgramRefactorTests
     }
 
     [Fact]
+    public void BuildArgumentList_UsCoreVersion_EmittedBeforeFhirExportLines()
+    {
+        // (A9) The us_core_version property must precede the format-export
+        // block so Synthea sees the IG choice before evaluating exporters.
+        var args = new SyntheaArgs(
+            State: null, City: null, Gender: null, AgeRange: null,
+            ModuleDir: null, Modules: null, Population: null, Seed: null,
+            Config: null, Zip: null, FhirVersion: null,
+            InitialSnapshot: null, UpdatedSnapshot: null, DaysForward: null,
+            Formats: new[] { "fhir" },
+            AdditionalFormats: System.Array.Empty<string>(),
+            Passthru: System.Array.Empty<string>(),
+            UsCoreVersion: "7");
+
+        var list = RunCommand.BuildArgumentList(args);
+        var enableIdx = list.IndexOf("--exporter.fhir.use_us_core_ig=true");
+        var verIdx = list.IndexOf("--exporter.fhir.us_core_version=7");
+        var exportTrueIdx = list.IndexOf("--exporter.fhir.export=true");
+        Assert.True(enableIdx >= 0, "use_us_core_ig=true missing");
+        Assert.True(verIdx >= 0, "us_core_version=7 missing");
+        Assert.True(exportTrueIdx >= 0, "fhir.export=true missing");
+        Assert.True(enableIdx < exportTrueIdx,
+            $"use_us_core_ig (idx {enableIdx}) must precede fhir.export=true (idx {exportTrueIdx})");
+        Assert.True(verIdx < exportTrueIdx,
+            $"us_core_version (idx {verIdx}) must precede fhir.export=true (idx {exportTrueIdx})");
+    }
+
+    [Fact]
+    public void BuildArgumentList_NoUsCoreVersion_OmitsBothProperties()
+    {
+        var args = new SyntheaArgs(
+            State: null, City: null, Gender: null, AgeRange: null,
+            ModuleDir: null, Modules: null, Population: null, Seed: null,
+            Config: null, Zip: null, FhirVersion: null,
+            InitialSnapshot: null, UpdatedSnapshot: null, DaysForward: null,
+            Formats: System.Array.Empty<string>(),
+            AdditionalFormats: System.Array.Empty<string>(),
+            Passthru: System.Array.Empty<string>());
+
+        var list = RunCommand.BuildArgumentList(args);
+        Assert.DoesNotContain("--exporter.fhir.use_us_core_ig=true", list);
+        Assert.DoesNotContain(list, s => s.StartsWith("--exporter.fhir.us_core_version="));
+    }
+
+    [Fact]
     public void CreateProcessStartInfo_UsesWorkingDirectoryAndJar()
     {
         var tmpDir = Path.Combine(Path.GetTempPath(), "synthea-test-tmp");


### PR DESCRIPTION
## Summary
- `--us-core-version` (allowlist: 3.1.1, 4, 5, 6, 7) — emits `--exporter.fhir.use_us_core_ig=true` + `--exporter.fhir.us_core_version=N` before the format-export block so Synthea sees the IG choice in time
- `--fhir-version` validator extended to accept `R5` in addition to `R4`/`STU3`

## v-next IDs
A9, A10

## Test plan
- [x] `UsCoreVersion_Allowed_EmitsBothProperties` theory across the 5 allowed values
- [x] `UsCoreVersion_OutsideAllowlist_Rejected`
- [x] `FhirVersion_R5_Accepted`, `FhirVersion_Bogus_Rejected`
- [x] `BuildArgumentList_UsCoreVersion_EmittedBeforeFhirExportLines` (ordering invariant)
- [x] `BuildArgumentList_NoUsCoreVersion_OmitsBothProperties` (off-by-default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)