### PR TITLE
feat(fhir): --flexporter-mapping, --ig-dir, --bulk-data (A5, A8)

### DIFF
--- a/src/Synthea.Cli/RunCommand.cs
+++ b/src/Synthea.Cli/RunCommand.cs
@@ -75,6 +75,12 @@ internal static class RunCommand
         };
         var propertyOpt = CreatePropertyOption();                 // A6
         var usCoreVerOpt = CreateUsCoreVersionOption();           // A9
+        var flexporterOpt = CreateFlexporterMappingOption();      // A5
+        var igDirOpt = CreateIgDirOption();                       // A5
+        var bulkDataOpt = new Option<bool>("--bulk-data")         // A8
+        {
+            Description = "Emit FHIR resources as bulk-data NDJSON (--exporter.fhir.bulk_data=true)."
+        };
         var passthru = CreatePassthruArgument();
 
         runCmd.Options.Add(outputOpt);
@@ -105,6 +111,9 @@ internal static class RunCommand
         runCmd.Options.Add(overflowOpt);
         runCmd.Options.Add(propertyOpt);
         runCmd.Options.Add(usCoreVerOpt);
+        runCmd.Options.Add(flexporterOpt);
+        runCmd.Options.Add(igDirOpt);
+        runCmd.Options.Add(bulkDataOpt);
         runCmd.Arguments.Add(passthru);
 
         runCmd.TreatUnmatchedTokensAsErrors = false;
@@ -116,7 +125,7 @@ internal static class RunCommand
                 fhirVerOpt, initialSnapOpt, updatedSnapOpt, daysForwardOpt, formatOpt, addFormatOpt,
                 jarOpt, insistChecksumOpt, passthru,
                 referenceDateOpt, endDateOpt, allowFutureEndOpt, clinicianSeedOpt, singlePersonSeedOpt, overflowOpt,
-                propertyOpt, usCoreVerOpt);
+                propertyOpt, usCoreVerOpt, flexporterOpt, igDirOpt, bulkDataOpt);
             var printArgs = parseResult.GetValue(printArgsOpt);
 
             // C7: malformed ~/.synthea-cli/config.json must fail the run with
@@ -334,6 +343,27 @@ internal static class RunCommand
             argList.Add("-o");
             argList.Add("true");
         }
+        // A5: Flexporter mapping (-fm <path>) and IG dir (-ig <dir>).
+        // Both Synthea flag-form; emit before --property/format blocks and
+        // before positional state so Synthea parses them as flags, not
+        // positionals. Paths normalized to absolute so cwd changes don't
+        // break the JAR's view of them.
+        if (o.FlexporterMapping is not null)
+        {
+            argList.Add("-fm");
+            argList.Add(Path.GetFullPath(o.FlexporterMapping.FullName));
+        }
+        if (o.IgDir is not null)
+        {
+            argList.Add("-ig");
+            argList.Add(Path.GetFullPath(o.IgDir.FullName));
+        }
+        // A8: bulk-data property — companion to the format block below;
+        // emitted as Synthea's `--exporter.fhir.bulk_data=true`.
+        if (o.BulkData)
+        {
+            argList.Add("--exporter.fhir.bulk_data=true");
+        }
         // A6: each --property KEY=VALUE becomes Synthea's documented
         // `--KEY=VALUE` form. The validator on the option guarantees a
         // single '=' and a well-formed key, so we don't re-check here.
@@ -470,7 +500,10 @@ internal static class RunCommand
         Option<int?> singlePersonSeedOpt,
         Option<bool> overflowOpt,
         Option<string[]> propertyOpt,
-        Option<string?> usCoreVerOpt)
+        Option<string?> usCoreVerOpt,
+        Option<FileInfo?> flexporterOpt,
+        Option<DirectoryInfo?> igDirOpt,
+        Option<bool> bulkDataOpt)
     {
         var javaPathArg = parseResult.GetValue(javaOpt);
         var hosting = new HostingOptions(
@@ -504,7 +537,10 @@ internal static class RunCommand
             SinglePersonSeed: parseResult.GetValue(singlePersonSeedOpt),
             Overflow: parseResult.GetValue(overflowOpt),
             Properties: parseResult.GetValue(propertyOpt),
-            UsCoreVersion: parseResult.GetValue(usCoreVerOpt));
+            UsCoreVersion: parseResult.GetValue(usCoreVerOpt),
+            FlexporterMapping: parseResult.GetValue(flexporterOpt),
+            IgDir: parseResult.GetValue(igDirOpt),
+            BulkData: parseResult.GetValue(bulkDataOpt));
         return (hosting, args);
     }
 
@@ -808,6 +844,32 @@ internal static class RunCommand
             Arity = ArgumentArity.ZeroOrMore
         };
         opt.Validators.Add(MultiTokenValidator(ValidateProperty));
+        return opt;
+    }
+
+    // A5: Flexporter mapping file (`-fm`). Existence is checked at parse
+    // time so we fail before launching the JVM rather than after.
+    private static Option<FileInfo?> CreateFlexporterMappingOption()
+    {
+        var opt = new Option<FileInfo?>("--flexporter-mapping")
+        {
+            Description = "Path to a Flexporter mapping file (.yaml/.json). Maps to Synthea -fm <path>."
+        };
+        opt.Validators.Add(SingleTokenValidator(v =>
+            File.Exists(v) ? null : $"Flexporter mapping file does not exist: '{v}'."));
+        return opt;
+    }
+
+    // A5: Custom Implementation Guide directory (`-ig`). Same pattern as
+    // --module-dir; existence checked up-front.
+    private static Option<DirectoryInfo?> CreateIgDirOption()
+    {
+        var opt = new Option<DirectoryInfo?>("--ig-dir")
+        {
+            Description = "Directory of FHIR Implementation Guide resources. Maps to Synthea -ig <dir>."
+        };
+        opt.Validators.Add(SingleTokenValidator(v =>
+            Directory.Exists(v) ? null : $"IG directory does not exist: '{v}'."));
         return opt;
     }
 

--- a/src/Synthea.Cli/SyntheaArgs.cs
+++ b/src/Synthea.Cli/SyntheaArgs.cs
@@ -41,4 +41,10 @@ internal record SyntheaArgs(
     // BOTH --exporter.fhir.use_us_core_ig=true AND
     // --exporter.fhir.us_core_version=N before any format-export lines, so
     // Synthea picks up the IG before deciding what to write.
-    string? UsCoreVersion = null);
+    string? UsCoreVersion = null,
+    // Phase 8 (A5+A8): Flexporter mapping + custom IG dir + bulk-data
+    // toggle. Flexporter and IG-dir map to Synthea's `-fm` / `-ig`
+    // positional-flag forms; BulkData maps to --exporter.fhir.bulk_data=true.
+    FileInfo? FlexporterMapping = null,
+    DirectoryInfo? IgDir = null,
+    bool BulkData = false);

--- a/tests/Synthea.Cli.UnitTests/ProgramHandlerTests.cs
+++ b/tests/Synthea.Cli.UnitTests/ProgramHandlerTests.cs
@@ -645,6 +645,65 @@ public class ProgramHandlerTests : IDisposable
         Assert.Null(_runner.StartInfo);
     }
 
+    // A5+A8 (Phase 8): Flexporter mapping + custom IG dir + bulk-data.
+
+    [Fact]
+    public async Task FlexporterMapping_ExistingFile_EmitsDashFm()
+    {
+        var mapping = Path.Combine(_tempDir, "flexporter.yaml");
+        File.WriteAllText(mapping, "mappings: []\n");
+        var outDir = Path.Combine(_tempDir, "out-flex");
+        var code = await Run("run", "--output", outDir, "--flexporter-mapping", mapping);
+        Assert.Equal(0, code);
+        var list = _runner.StartInfo!.ArgumentList;
+        var fmIdx = list.IndexOf("-fm");
+        Assert.True(fmIdx >= 0);
+        Assert.Equal(Path.GetFullPath(mapping), list[fmIdx + 1]);
+    }
+
+    [Fact]
+    public async Task FlexporterMapping_MissingFile_Rejected()
+    {
+        var outDir = Path.Combine(_tempDir, "out-flex-bad");
+        var code = await Run("run", "--output", outDir,
+            "--flexporter-mapping", Path.Combine(_tempDir, "does-not-exist.yaml"));
+        Assert.NotEqual(0, code);
+        Assert.Null(_runner.StartInfo);
+    }
+
+    [Fact]
+    public async Task IgDir_ExistingDirectory_EmitsDashIg()
+    {
+        var ig = Path.Combine(_tempDir, "ig");
+        Directory.CreateDirectory(ig);
+        var outDir = Path.Combine(_tempDir, "out-ig");
+        var code = await Run("run", "--output", outDir, "--ig-dir", ig);
+        Assert.Equal(0, code);
+        var list = _runner.StartInfo!.ArgumentList;
+        var igIdx = list.IndexOf("-ig");
+        Assert.True(igIdx >= 0);
+        Assert.Equal(Path.GetFullPath(ig), list[igIdx + 1]);
+    }
+
+    [Fact]
+    public async Task IgDir_MissingDirectory_Rejected()
+    {
+        var outDir = Path.Combine(_tempDir, "out-ig-bad");
+        var code = await Run("run", "--output", outDir,
+            "--ig-dir", Path.Combine(_tempDir, "no-such-dir"));
+        Assert.NotEqual(0, code);
+        Assert.Null(_runner.StartInfo);
+    }
+
+    [Fact]
+    public async Task BulkData_Flag_EmitsExporterProperty()
+    {
+        var outDir = Path.Combine(_tempDir, "out-bulk");
+        var code = await Run("run", "--output", outDir, "--bulk-data");
+        Assert.Equal(0, code);
+        Assert.Contains("--exporter.fhir.bulk_data=true", _runner.StartInfo!.ArgumentList);
+    }
+
     [Fact]
     public async Task JavaProcess_NonZeroExit_WithRecognizedStderr_StillReturnsJavasExitCode()
     {

--- a/tests/Synthea.Cli.UnitTests/ProgramRefactorTests.cs
+++ b/tests/Synthea.Cli.UnitTests/ProgramRefactorTests.cs
@@ -270,6 +270,57 @@ public class ProgramRefactorTests
     }
 
     [Fact]
+    public void BuildArgumentList_FlexporterIgBulk_EmittedBeforePositionalState()
+    {
+        // (A5+A8) -fm/-ig are Synthea flag-form; --exporter.fhir.bulk_data
+        // is a property. All three must precede the positional state arg
+        // (and thus the passthru tail), matching how the existing flag
+        // block is laid out.
+        var args = new SyntheaArgs(
+            State: "OH", City: null, Gender: null, AgeRange: null,
+            ModuleDir: null, Modules: null, Population: null, Seed: null,
+            Config: null, Zip: null, FhirVersion: null,
+            InitialSnapshot: null, UpdatedSnapshot: null, DaysForward: null,
+            Formats: System.Array.Empty<string>(),
+            AdditionalFormats: System.Array.Empty<string>(),
+            Passthru: System.Array.Empty<string>(),
+            FlexporterMapping: new FileInfo("/tmp/map.yaml"),
+            IgDir: new DirectoryInfo("/tmp/ig"),
+            BulkData: true);
+
+        var list = RunCommand.BuildArgumentList(args);
+        var fmIdx = list.IndexOf("-fm");
+        var igIdx = list.IndexOf("-ig");
+        var bulkIdx = list.IndexOf("--exporter.fhir.bulk_data=true");
+        var stateIdx = list.IndexOf("OH");
+        Assert.True(fmIdx >= 0 && igIdx >= 0 && bulkIdx >= 0 && stateIdx >= 0);
+        Assert.True(fmIdx < stateIdx, $"-fm ({fmIdx}) must precede state ({stateIdx})");
+        Assert.True(igIdx < stateIdx, $"-ig ({igIdx}) must precede state ({stateIdx})");
+        Assert.True(bulkIdx < stateIdx, $"bulk_data ({bulkIdx}) must precede state ({stateIdx})");
+        // Paths must be absolute (Path.GetFullPath was applied).
+        Assert.Equal(Path.GetFullPath("/tmp/map.yaml"), list[fmIdx + 1]);
+        Assert.Equal(Path.GetFullPath("/tmp/ig"), list[igIdx + 1]);
+    }
+
+    [Fact]
+    public void BuildArgumentList_NoFlexporterIgBulk_NoneEmitted()
+    {
+        var args = new SyntheaArgs(
+            State: null, City: null, Gender: null, AgeRange: null,
+            ModuleDir: null, Modules: null, Population: null, Seed: null,
+            Config: null, Zip: null, FhirVersion: null,
+            InitialSnapshot: null, UpdatedSnapshot: null, DaysForward: null,
+            Formats: System.Array.Empty<string>(),
+            AdditionalFormats: System.Array.Empty<string>(),
+            Passthru: System.Array.Empty<string>());
+
+        var list = RunCommand.BuildArgumentList(args);
+        Assert.DoesNotContain("-fm", list);
+        Assert.DoesNotContain("-ig", list);
+        Assert.DoesNotContain("--exporter.fhir.bulk_data=true", list);
+    }
+
+    [Fact]
     public void CreateProcessStartInfo_UsesWorkingDirectoryAndJar()
     {
         var tmpDir = Path.Combine(Path.GetTempPath(), "synthea-test-tmp");


### PR DESCRIPTION
## Summary
- `--flexporter-mapping <file>` → Synthea `-fm <abs-path>` (file-exists validator)
- `--ig-dir <dir>` → Synthea `-ig <abs-path>` (dir-exists validator)
- `--bulk-data` → `--exporter.fhir.bulk_data=true`

Paths are normalized to absolute so cwd changes don't break the JAR's view.

## v-next IDs
A5, A8

## Test plan
- [x] `FlexporterMapping_ExistingFile_EmitsDashFm` + `_MissingFile_Rejected`
- [x] `IgDir_ExistingDirectory_EmitsDashIg` + `_MissingDirectory_Rejected`
- [x] `BulkData_Flag_EmitsExporterProperty`
- [x] `BuildArgumentList_FlexporterIgBulk_EmittedBeforePositionalState` (ordering invariant + absolute-path normalization)
- [x] `BuildArgumentList_NoFlexporterIgBulk_NoneEmitted` (off-by-default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)