### PR TITLE
feat(doctor): synthea doctor subcommand for environment checks (B6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,15 @@ synthea --verbose run -o ./output -p 5 --state OH
 synthea --quiet run -o ./output -p 5 --state OH
 ```
 
+### Environment check
+
+```bash
+# Probe Java, cache dir, cached JAR age, config file, GitHub reachability, and free disk
+synthea doctor
+# Exits 0 on OK + WARN, exits 1 on any FAIL. Warnings are informational —
+# `--jar` lets you bypass GitHub entirely if the reachability probe is unhappy.
+```
+
 ---
 
 ## Cache management

--- a/src/Synthea.Cli/DoctorCheck.cs
+++ b/src/Synthea.Cli/DoctorCheck.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Synthea.Cli;
+
+// Three-level severity matches the plan's exit-code policy: Ok and Warn
+// are both exit 0; Fail is the only thing that promotes the run to exit 1.
+internal enum DoctorSeverity
+{
+    Ok,
+    Warn,
+    Fail,
+}
+
+internal sealed record DoctorCheckResult(string Name, DoctorSeverity Severity, string Message);
+
+internal interface IDoctorCheck
+{
+    Task<DoctorCheckResult> RunAsync(CancellationToken cancelToken);
+}
+
+// Tiny shim around File.WriteAllText/File.Delete so the cache-dir-writeable
+// check can be tested without touching the real filesystem. Production
+// uses DefaultFileSystem; tests substitute an in-memory stub.
+internal interface IFileSystem
+{
+    bool TryProbeWrite(string directoryPath, out string? errorMessage);
+}
+
+internal sealed class DefaultFileSystem : IFileSystem
+{
+    public bool TryProbeWrite(string directoryPath, out string? errorMessage)
+    {
+        errorMessage = null;
+        try
+        {
+            if (!Directory.Exists(directoryPath))
+                Directory.CreateDirectory(directoryPath);
+            var probe = Path.Combine(directoryPath, ".synthea-cli-write-probe-" + Guid.NewGuid().ToString("N"));
+            File.WriteAllText(probe, "ok");
+            File.Delete(probe);
+            return true;
+        }
+        catch (IOException ex)
+        {
+            errorMessage = ex.Message;
+            return false;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            errorMessage = ex.Message;
+            return false;
+        }
+    }
+}

--- a/src/Synthea.Cli/DoctorCommand.cs
+++ b/src/Synthea.Cli/DoctorCommand.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Synthea.Cli;
+
+// `synthea doctor` — runs six environment checks and prints a one-line
+// status per check. Exit policy: any FAIL → exit 1; OK + WARN-only → exit 0
+// (warnings are informational; `--jar` lets users work around most of them).
+// (B6)
+internal static class DoctorCommand
+{
+    // Thresholds promoted to constants so tests pin behavior without
+    // magic numbers drifting between source and asserts.
+    internal const int CachedJarWarnAgeDays = 90;
+    internal const int CachedJarStaleAgeDays = 180;
+    internal const long DiskSpaceFailBytes = 200L * 1024 * 1024;        // 200 MB
+    internal const long DiskSpaceWarnBytes = 1L * 1024 * 1024 * 1024;   // 1 GB
+    internal static readonly TimeSpan GitHubProbeTimeout = TimeSpan.FromSeconds(5);
+
+    internal static Command Build(
+        IJarSource jarSource,
+        IJavaDetector javaDetector,
+        IFileSystem fileSystem,
+        IGitHubReachabilityProbe gitHubProbe,
+        IDiskSpaceProbe diskProbe,
+        Option<string?> javaOpt)
+    {
+        var cmd = new Command("doctor", "Run environment checks and report Java, cache, config, network, and disk status");
+
+        cmd.SetAction(async (ParseResult parseResult, CancellationToken cancelToken) =>
+        {
+            var javaPathArg = parseResult.GetValue(javaOpt);
+            var javaPath = string.IsNullOrWhiteSpace(javaPathArg) ? "java" : javaPathArg!;
+
+            var checks = BuildChecks(
+                javaPath: javaPath,
+                javaDetector: javaDetector,
+                jarSource: jarSource,
+                fileSystem: fileSystem,
+                gitHubProbe: gitHubProbe,
+                diskProbe: diskProbe,
+                configPath: null,
+                clock: null);
+
+            var results = new List<DoctorCheckResult>(checks.Count);
+            foreach (var check in checks)
+                results.Add(await check.RunAsync(cancelToken));
+
+            Console.WriteLine(FormatReport(results));
+            return ExitCodeFor(results);
+        });
+
+        return cmd;
+    }
+
+    internal static IReadOnlyList<IDoctorCheck> BuildChecks(
+        string javaPath,
+        IJavaDetector javaDetector,
+        IJarSource jarSource,
+        IFileSystem fileSystem,
+        IGitHubReachabilityProbe gitHubProbe,
+        IDiskSpaceProbe diskProbe,
+        string? configPath,
+        Func<DateTime>? clock)
+    {
+        var now = clock ?? (() => DateTime.UtcNow);
+        return new IDoctorCheck[]
+        {
+            new JavaCheck(javaPath, javaDetector),
+            new CacheDirCheck(jarSource, fileSystem),
+            new CachedJarCheck(jarSource, now),
+            new ConfigCheck(configPath),
+            new GitHubCheck(gitHubProbe),
+            new DiskSpaceCheck(jarSource, diskProbe),
+        };
+    }
+
+    internal static int ExitCodeFor(IReadOnlyList<DoctorCheckResult> results)
+        => results.Any(r => r.Severity == DoctorSeverity.Fail) ? 1 : 0;
+
+    internal static string FormatReport(IReadOnlyList<DoctorCheckResult> results)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("synthea doctor — environment check");
+        sb.AppendLine();
+
+        // Pad the check name to the widest one so the message column lines
+        // up. Constant width across runs would be tidier but pads the
+        // common case unnecessarily.
+        var nameWidth = results.Count == 0 ? 0 : results.Max(r => r.Name.Length);
+        foreach (var r in results)
+        {
+            sb.Append(SeverityTag(r.Severity));
+            sb.Append("   ");
+            sb.Append(r.Name.PadRight(nameWidth));
+            sb.Append("   ");
+            sb.AppendLine(r.Message);
+        }
+
+        sb.AppendLine();
+        var failCount = results.Count(r => r.Severity == DoctorSeverity.Fail);
+        var warnCount = results.Count(r => r.Severity == DoctorSeverity.Warn);
+        if (failCount > 0)
+            sb.Append($"{failCount} critical issue{(failCount == 1 ? "" : "s")} found.");
+        else if (warnCount > 0)
+            sb.Append($"{warnCount} warning{(warnCount == 1 ? "" : "s")}; CLI should still run.");
+        else
+            sb.Append("All checks passed.");
+        return sb.ToString();
+    }
+
+    private static string SeverityTag(DoctorSeverity severity) => severity switch
+    {
+        DoctorSeverity.Ok => "[ OK ]",
+        DoctorSeverity.Warn => "[WARN]",
+        DoctorSeverity.Fail => "[FAIL]",
+        _ => "[????]",
+    };
+
+    // ----- Check implementations ----------------------------------------
+
+    internal sealed class JavaCheck : IDoctorCheck
+    {
+        private readonly string _javaPath;
+        private readonly IJavaDetector _detector;
+        public JavaCheck(string javaPath, IJavaDetector detector)
+        {
+            _javaPath = javaPath;
+            _detector = detector;
+        }
+
+        public async Task<DoctorCheckResult> RunAsync(CancellationToken cancelToken)
+        {
+            var probe = await _detector.ProbeAsync(_javaPath, cancelToken);
+            if (!probe.Found)
+                return new("Java", DoctorSeverity.Fail,
+                    $"not found at '{_javaPath}' ({probe.ErrorMessage ?? "no java -version output"})");
+            if (probe.MajorVersion is null)
+                return new("Java", DoctorSeverity.Fail,
+                    $"could not parse version from '{_javaPath}' (raw: {probe.RawVersionString ?? "?"})");
+            if (probe.MajorVersion.Value < 17)
+                return new("Java", DoctorSeverity.Fail,
+                    $"Java {probe.MajorVersion} (Synthea requires 17 or later — see https://adoptium.net)");
+            return new("Java", DoctorSeverity.Ok, $"Java {probe.RawVersionString ?? probe.MajorVersion.ToString()}");
+        }
+    }
+
+    internal sealed class CacheDirCheck : IDoctorCheck
+    {
+        private readonly IJarSource _jarSource;
+        private readonly IFileSystem _fs;
+        public CacheDirCheck(IJarSource jarSource, IFileSystem fs)
+        {
+            _jarSource = jarSource;
+            _fs = fs;
+        }
+
+        public Task<DoctorCheckResult> RunAsync(CancellationToken cancelToken)
+        {
+            var dir = _jarSource.CachePath;
+            if (_fs.TryProbeWrite(dir, out var err))
+                return Task.FromResult(new DoctorCheckResult("Cache dir", DoctorSeverity.Ok, $"{dir} (writeable)"));
+            return Task.FromResult(new DoctorCheckResult("Cache dir", DoctorSeverity.Fail, $"{dir} not writeable: {err}"));
+        }
+    }
+
+    internal sealed class CachedJarCheck : IDoctorCheck
+    {
+        private readonly IJarSource _jarSource;
+        private readonly Func<DateTime> _now;
+        public CachedJarCheck(IJarSource jarSource, Func<DateTime> now)
+        {
+            _jarSource = jarSource;
+            _now = now;
+        }
+
+        public Task<DoctorCheckResult> RunAsync(CancellationToken cancelToken)
+        {
+            var jar = _jarSource.TryFindCachedJar();
+            if (jar is null)
+                return Task.FromResult(new DoctorCheckResult(
+                    "Cached JAR", DoctorSeverity.Warn,
+                    "no JAR cached yet — will download on first run"));
+            var ageDays = (_now() - jar.LastWriteTimeUtc).TotalDays;
+            var sizeMb = jar.Length / (1024.0 * 1024.0);
+            var detail = $"{jar.Name} ({(int)ageDays}d old, {sizeMb:0} MB)";
+            if (ageDays >= CachedJarStaleAgeDays)
+                return Task.FromResult(new DoctorCheckResult(
+                    "Cached JAR", DoctorSeverity.Warn, detail + " — consider --refresh"));
+            if (ageDays >= CachedJarWarnAgeDays)
+                return Task.FromResult(new DoctorCheckResult(
+                    "Cached JAR", DoctorSeverity.Warn, detail));
+            return Task.FromResult(new DoctorCheckResult(
+                "Cached JAR", DoctorSeverity.Ok, detail));
+        }
+    }
+
+    internal sealed class ConfigCheck : IDoctorCheck
+    {
+        private readonly string? _configPath;
+        public ConfigCheck(string? configPath) => _configPath = configPath;
+
+        public Task<DoctorCheckResult> RunAsync(CancellationToken cancelToken)
+        {
+            var path = _configPath ?? CliConfig.DefaultPath();
+            if (!File.Exists(path))
+                return Task.FromResult(new DoctorCheckResult(
+                    "Config", DoctorSeverity.Ok, $"no config file at {path} (defaults apply)"));
+            try
+            {
+                _ = CliConfig.LoadOrThrow(path);
+                return Task.FromResult(new DoctorCheckResult(
+                    "Config", DoctorSeverity.Ok, $"{path} (valid)"));
+            }
+            catch (CliConfigException ex)
+            {
+                return Task.FromResult(new DoctorCheckResult(
+                    "Config", DoctorSeverity.Fail, ex.Message));
+            }
+        }
+    }
+
+    internal sealed class GitHubCheck : IDoctorCheck
+    {
+        private readonly IGitHubReachabilityProbe _probe;
+        public GitHubCheck(IGitHubReachabilityProbe probe) => _probe = probe;
+
+        public async Task<DoctorCheckResult> RunAsync(CancellationToken cancelToken)
+        {
+            var r = await _probe.PingAsync(GitHubProbeTimeout, cancelToken);
+            if (r.Reachable)
+            {
+                var elapsed = r.ElapsedMilliseconds.HasValue ? $", {r.ElapsedMilliseconds}ms" : "";
+                return new("GitHub", DoctorSeverity.Ok, $"api.github.com reachable (HTTP {r.StatusCode}{elapsed})");
+            }
+            if (r.StatusCode is int code)
+                return new("GitHub", DoctorSeverity.Warn,
+                    $"api.github.com returned HTTP {code} — --jar can bypass GitHub entirely");
+            return new("GitHub", DoctorSeverity.Warn,
+                $"api.github.com unreachable ({r.ErrorMessage ?? "unknown error"}) — --jar can bypass GitHub entirely");
+        }
+    }
+
+    internal sealed class DiskSpaceCheck : IDoctorCheck
+    {
+        private readonly IJarSource _jarSource;
+        private readonly IDiskSpaceProbe _probe;
+        public DiskSpaceCheck(IJarSource jarSource, IDiskSpaceProbe probe)
+        {
+            _jarSource = jarSource;
+            _probe = probe;
+        }
+
+        public Task<DoctorCheckResult> RunAsync(CancellationToken cancelToken)
+        {
+            var dir = _jarSource.CachePath;
+            var free = _probe.GetFreeBytes(dir);
+            if (free is null)
+                return Task.FromResult(new DoctorCheckResult(
+                    "Disk space", DoctorSeverity.Warn,
+                    $"could not determine free space for {dir}"));
+            var bytes = free.Value;
+            var human = FormatBytes(bytes);
+            if (bytes < DiskSpaceFailBytes)
+                return Task.FromResult(new DoctorCheckResult(
+                    "Disk space", DoctorSeverity.Fail,
+                    $"only {human} free in cache dir — Synthea JAR is ~180 MB"));
+            if (bytes < DiskSpaceWarnBytes)
+                return Task.FromResult(new DoctorCheckResult(
+                    "Disk space", DoctorSeverity.Warn,
+                    $"{human} free in cache dir"));
+            return Task.FromResult(new DoctorCheckResult(
+                "Disk space", DoctorSeverity.Ok, $"{human} free in cache dir"));
+        }
+
+        private static string FormatBytes(long bytes)
+        {
+            const double GB = 1024.0 * 1024.0 * 1024.0;
+            const double MB = 1024.0 * 1024.0;
+            if (bytes >= GB) return $"{bytes / GB:0.0} GB";
+            return $"{bytes / MB:0} MB";
+        }
+    }
+}

--- a/src/Synthea.Cli/IDiskSpaceProbe.cs
+++ b/src/Synthea.Cli/IDiskSpaceProbe.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+
+namespace Synthea.Cli;
+
+internal interface IDiskSpaceProbe
+{
+    long? GetFreeBytes(string path);
+}
+
+// Real probe: matches the directory's drive root against DriveInfo.GetDrives.
+// Returns null if no matching drive is found (e.g. UNC path on Linux) so the
+// doctor check can downgrade to Warn rather than guess at a number.
+internal sealed class DefaultDiskSpaceProbe : IDiskSpaceProbe
+{
+    public long? GetFreeBytes(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return null;
+        try
+        {
+            var root = Path.GetPathRoot(Path.GetFullPath(path));
+            if (string.IsNullOrWhiteSpace(root)) return null;
+            foreach (var drive in DriveInfo.GetDrives())
+            {
+                if (string.Equals(drive.Name, root, StringComparison.OrdinalIgnoreCase) && drive.IsReady)
+                    return drive.AvailableFreeSpace;
+            }
+            return null;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Synthea.Cli/IGitHubReachabilityProbe.cs
+++ b/src/Synthea.Cli/IGitHubReachabilityProbe.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Synthea.Cli;
+
+internal sealed record GitHubReachabilityResult(
+    bool Reachable,
+    int? StatusCode,
+    long? ElapsedMilliseconds,
+    string? ErrorMessage);
+
+internal interface IGitHubReachabilityProbe
+{
+    Task<GitHubReachabilityResult> PingAsync(TimeSpan timeout, CancellationToken cancelToken);
+}
+
+// Real probe: HEAD against the synthea releases endpoint we rely on. A
+// failed ping is reported as Warn (the user can still use --jar to bypass
+// GitHub entirely), so network blips don't turn `synthea doctor` red.
+internal sealed class HttpGitHubReachabilityProbe : IGitHubReachabilityProbe
+{
+    private const string ProbeUrl = "https://api.github.com/repos/synthetichealth/synthea";
+
+    private readonly HttpClient _http;
+
+    public HttpGitHubReachabilityProbe(HttpClient http) => _http = http;
+
+    public async Task<GitHubReachabilityResult> PingAsync(TimeSpan timeout, CancellationToken cancelToken)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancelToken);
+        cts.CancelAfter(timeout);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        try
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Head, ProbeUrl);
+            using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+            sw.Stop();
+            return new GitHubReachabilityResult(
+                Reachable: resp.IsSuccessStatusCode,
+                StatusCode: (int)resp.StatusCode,
+                ElapsedMilliseconds: sw.ElapsedMilliseconds,
+                ErrorMessage: null);
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested && !cancelToken.IsCancellationRequested)
+        {
+            sw.Stop();
+            return new GitHubReachabilityResult(false, null, sw.ElapsedMilliseconds, $"timed out after {timeout.TotalSeconds:0.0}s");
+        }
+        catch (HttpRequestException ex)
+        {
+            sw.Stop();
+            return new GitHubReachabilityResult(false, null, sw.ElapsedMilliseconds, ex.Message);
+        }
+    }
+}

--- a/src/Synthea.Cli/Program.cs
+++ b/src/Synthea.Cli/Program.cs
@@ -44,6 +44,12 @@ internal static class Program
         sc.AddSingleton<IJarSource>(sp => new JarManager(
             http: BuildHttpClient(CliConfig.Load()),
             logger: sp.GetRequiredService<ILogger<JarManager>>()));
+        // (B6) `synthea doctor` needs lightweight probes. The HttpClient
+        // used for the reachability probe is independent of the JarManager
+        // client so the proxy/UA chain stays single-purpose there.
+        sc.AddSingleton<IFileSystem, DefaultFileSystem>();
+        sc.AddSingleton<IDiskSpaceProbe, DefaultDiskSpaceProbe>();
+        sc.AddSingleton<IGitHubReachabilityProbe>(_ => new HttpGitHubReachabilityProbe(BuildHttpClient(CliConfig.Load())));
         return sc.BuildServiceProvider();
     }
 
@@ -71,6 +77,13 @@ internal static class Program
         var runner = services.GetRequiredService<IProcessRunner>();
         var jarSource = services.GetRequiredService<IJarSource>();
         var javaDetector = services.GetRequiredService<IJavaDetector>();
+        // Doctor-only services: fall back to defaults so test fixtures that
+        // pre-date Phase 9 don't have to register every interface to exercise
+        // `synthea run`. Production wires real impls via BuildDefaultServices.
+        var fileSystem = services.GetService<IFileSystem>() ?? new DefaultFileSystem();
+        var diskProbe = services.GetService<IDiskSpaceProbe>() ?? new DefaultDiskSpaceProbe();
+        var gitHubProbe = services.GetService<IGitHubReachabilityProbe>()
+            ?? new HttpGitHubReachabilityProbe(BuildHttpClient(CliConfig.Load()));
 
         var root = new RootCommand("CLI wrapper around MITRE Synthea synthetic patient generator");
 
@@ -113,6 +126,7 @@ internal static class Program
 
         root.Subcommands.Add(RunCommand.Build(runner, jarSource, javaDetector, refreshOpt, javaOpt, skipJdkCheckOpt));
         root.Subcommands.Add(CacheCommand.Build(jarSource));
+        root.Subcommands.Add(DoctorCommand.Build(jarSource, javaDetector, fileSystem, gitHubProbe, diskProbe, javaOpt));
 
         if (args.Length == 0) args = new[] { "--help" };
         return await root.Parse(args).InvokeAsync();

--- a/tests/Synthea.Cli.UnitTests/DoctorCheckTests.cs
+++ b/tests/Synthea.Cli.UnitTests/DoctorCheckTests.cs
@@ -1,0 +1,287 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Synthea.Cli;
+using Xunit;
+
+namespace Synthea.Cli.UnitTests;
+
+public class DoctorCheckTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public DoctorCheckTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, true); } catch { }
+    }
+
+    // ----- JavaCheck ------------------------------------------------------
+
+    [Fact]
+    public async Task JavaCheck_Modern_ReturnsOk()
+    {
+        var check = new DoctorCommand.JavaCheck("java", new StubJavaDetector(new JavaProbeResult(true, 21, "21.0.5", null)));
+        var r = await check.RunAsync(default);
+        Assert.Equal(DoctorSeverity.Ok, r.Severity);
+        Assert.Contains("21", r.Message);
+    }
+
+    [Fact]
+    public async Task JavaCheck_TooOld_ReturnsFail()
+    {
+        var check = new DoctorCommand.JavaCheck("java", new StubJavaDetector(new JavaProbeResult(true, 11, "11.0.20", null)));
+        var r = await check.RunAsync(default);
+        Assert.Equal(DoctorSeverity.Fail, r.Severity);
+        Assert.Contains("17", r.Message);
+    }
+
+    [Fact]
+    public async Task JavaCheck_NotFound_ReturnsFail()
+    {
+        var check = new DoctorCommand.JavaCheck("java", new StubJavaDetector(new JavaProbeResult(false, null, null, "not found")));
+        var r = await check.RunAsync(default);
+        Assert.Equal(DoctorSeverity.Fail, r.Severity);
+    }
+
+    // ----- CacheDirCheck --------------------------------------------------
+
+    [Fact]
+    public async Task CacheDirCheck_Writeable_ReturnsOk()
+    {
+        var jar = new StubJarSource(_tempDir, cachedJar: null);
+        var fs = new StubFileSystem(canWrite: true);
+        var r = await new DoctorCommand.CacheDirCheck(jar, fs).RunAsync(default);
+        Assert.Equal(DoctorSeverity.Ok, r.Severity);
+    }
+
+    [Fact]
+    public async Task CacheDirCheck_NotWriteable_ReturnsFail()
+    {
+        var jar = new StubJarSource(_tempDir, cachedJar: null);
+        var fs = new StubFileSystem(canWrite: false, error: "permission denied");
+        var r = await new DoctorCommand.CacheDirCheck(jar, fs).RunAsync(default);
+        Assert.Equal(DoctorSeverity.Fail, r.Severity);
+        Assert.Contains("permission denied", r.Message);
+    }
+
+    // ----- CachedJarCheck -------------------------------------------------
+
+    [Fact]
+    public async Task CachedJarCheck_NoneCached_ReturnsWarn()
+    {
+        var jar = new StubJarSource(_tempDir, cachedJar: null);
+        var r = await new DoctorCommand.CachedJarCheck(jar, () => DateTime.UtcNow).RunAsync(default);
+        Assert.Equal(DoctorSeverity.Warn, r.Severity);
+        Assert.Contains("no JAR cached", r.Message);
+    }
+
+    [Fact]
+    public async Task CachedJarCheck_Fresh_ReturnsOk()
+    {
+        var jarPath = Path.Combine(_tempDir, "synthea-with-dependencies.jar");
+        File.WriteAllBytes(jarPath, new byte[1024 * 1024]); // 1 MB
+        File.SetLastWriteTimeUtc(jarPath, DateTime.UtcNow.AddDays(-5));
+        var jar = new StubJarSource(_tempDir, new FileInfo(jarPath));
+        var r = await new DoctorCommand.CachedJarCheck(jar, () => DateTime.UtcNow).RunAsync(default);
+        Assert.Equal(DoctorSeverity.Ok, r.Severity);
+    }
+
+    [Fact]
+    public async Task CachedJarCheck_Stale_ReturnsWarnWithRefreshHint()
+    {
+        var jarPath = Path.Combine(_tempDir, "synthea-with-dependencies.jar");
+        File.WriteAllBytes(jarPath, new byte[1024]);
+        File.SetLastWriteTimeUtc(jarPath, DateTime.UtcNow.AddDays(-200));
+        var jar = new StubJarSource(_tempDir, new FileInfo(jarPath));
+        var r = await new DoctorCommand.CachedJarCheck(jar, () => DateTime.UtcNow).RunAsync(default);
+        Assert.Equal(DoctorSeverity.Warn, r.Severity);
+        Assert.Contains("--refresh", r.Message);
+    }
+
+    [Fact]
+    public async Task CachedJarCheck_Aging_ReturnsWarn()
+    {
+        var jarPath = Path.Combine(_tempDir, "synthea-with-dependencies.jar");
+        File.WriteAllBytes(jarPath, new byte[1024]);
+        File.SetLastWriteTimeUtc(jarPath, DateTime.UtcNow.AddDays(-120));
+        var jar = new StubJarSource(_tempDir, new FileInfo(jarPath));
+        var r = await new DoctorCommand.CachedJarCheck(jar, () => DateTime.UtcNow).RunAsync(default);
+        Assert.Equal(DoctorSeverity.Warn, r.Severity);
+        Assert.DoesNotContain("--refresh", r.Message);
+    }
+
+    // ----- ConfigCheck ----------------------------------------------------
+
+    [Fact]
+    public async Task ConfigCheck_Missing_ReturnsOk()
+    {
+        var path = Path.Combine(_tempDir, "no-config.json");
+        var r = await new DoctorCommand.ConfigCheck(path).RunAsync(default);
+        Assert.Equal(DoctorSeverity.Ok, r.Severity);
+        Assert.Contains("no config file", r.Message);
+    }
+
+    [Fact]
+    public async Task ConfigCheck_Valid_ReturnsOk()
+    {
+        var path = Path.Combine(_tempDir, "good.json");
+        File.WriteAllText(path, """{ "jarPath": "/x/y.jar" }""");
+        var r = await new DoctorCommand.ConfigCheck(path).RunAsync(default);
+        Assert.Equal(DoctorSeverity.Ok, r.Severity);
+        Assert.Contains("valid", r.Message);
+    }
+
+    [Fact]
+    public async Task ConfigCheck_Malformed_ReturnsFail()
+    {
+        var path = Path.Combine(_tempDir, "broken.json");
+        File.WriteAllText(path, "{not valid");
+        var r = await new DoctorCommand.ConfigCheck(path).RunAsync(default);
+        Assert.Equal(DoctorSeverity.Fail, r.Severity);
+        Assert.Contains(path, r.Message);
+    }
+
+    // ----- GitHubCheck ----------------------------------------------------
+
+    [Fact]
+    public async Task GitHubCheck_Reachable_ReturnsOk()
+    {
+        var probe = new StubGitHubProbe(new GitHubReachabilityResult(true, 200, 198, null));
+        var r = await new DoctorCommand.GitHubCheck(probe).RunAsync(default);
+        Assert.Equal(DoctorSeverity.Ok, r.Severity);
+        Assert.Contains("200", r.Message);
+    }
+
+    [Fact]
+    public async Task GitHubCheck_Timeout_ReturnsWarn()
+    {
+        var probe = new StubGitHubProbe(new GitHubReachabilityResult(false, null, 5000, "timed out after 5.0s"));
+        var r = await new DoctorCommand.GitHubCheck(probe).RunAsync(default);
+        Assert.Equal(DoctorSeverity.Warn, r.Severity);
+        Assert.Contains("--jar", r.Message);
+    }
+
+    [Fact]
+    public async Task GitHubCheck_HttpError_ReturnsWarn()
+    {
+        var probe = new StubGitHubProbe(new GitHubReachabilityResult(false, 503, 100, null));
+        var r = await new DoctorCommand.GitHubCheck(probe).RunAsync(default);
+        Assert.Equal(DoctorSeverity.Warn, r.Severity);
+        Assert.Contains("503", r.Message);
+    }
+
+    // ----- DiskSpaceCheck -------------------------------------------------
+
+    [Fact]
+    public async Task DiskSpaceCheck_Plenty_ReturnsOk()
+    {
+        var jar = new StubJarSource(_tempDir, cachedJar: null);
+        var probe = new StubDiskSpaceProbe(45L * 1024 * 1024 * 1024); // 45 GB
+        var r = await new DoctorCommand.DiskSpaceCheck(jar, probe).RunAsync(default);
+        Assert.Equal(DoctorSeverity.Ok, r.Severity);
+    }
+
+    [Fact]
+    public async Task DiskSpaceCheck_Tight_ReturnsWarn()
+    {
+        var jar = new StubJarSource(_tempDir, cachedJar: null);
+        var probe = new StubDiskSpaceProbe(500L * 1024 * 1024); // 500 MB
+        var r = await new DoctorCommand.DiskSpaceCheck(jar, probe).RunAsync(default);
+        Assert.Equal(DoctorSeverity.Warn, r.Severity);
+    }
+
+    [Fact]
+    public async Task DiskSpaceCheck_Tiny_ReturnsFail()
+    {
+        var jar = new StubJarSource(_tempDir, cachedJar: null);
+        var probe = new StubDiskSpaceProbe(100L * 1024 * 1024); // 100 MB
+        var r = await new DoctorCommand.DiskSpaceCheck(jar, probe).RunAsync(default);
+        Assert.Equal(DoctorSeverity.Fail, r.Severity);
+    }
+
+    [Fact]
+    public async Task DiskSpaceCheck_Unknown_ReturnsWarn()
+    {
+        var jar = new StubJarSource(_tempDir, cachedJar: null);
+        var probe = new StubDiskSpaceProbe(null);
+        var r = await new DoctorCommand.DiskSpaceCheck(jar, probe).RunAsync(default);
+        Assert.Equal(DoctorSeverity.Warn, r.Severity);
+    }
+
+    // ----- Default file system probe (writeable smoke) --------------------
+
+    [Fact]
+    public void DefaultFileSystem_WriteableTemp_ReturnsTrue()
+    {
+        var fs = new DefaultFileSystem();
+        Assert.True(fs.TryProbeWrite(_tempDir, out var err));
+        Assert.Null(err);
+    }
+
+    // ----- Stubs ----------------------------------------------------------
+
+    private sealed class StubJavaDetector : IJavaDetector
+    {
+        private readonly JavaProbeResult _result;
+        public StubJavaDetector(JavaProbeResult result) => _result = result;
+        public Task<JavaProbeResult> ProbeAsync(string javaPath, CancellationToken cancelToken = default)
+            => Task.FromResult(_result);
+    }
+
+    private sealed class StubFileSystem : IFileSystem
+    {
+        private readonly bool _canWrite;
+        private readonly string? _error;
+        public StubFileSystem(bool canWrite, string? error = null)
+        {
+            _canWrite = canWrite;
+            _error = error;
+        }
+        public bool TryProbeWrite(string directoryPath, out string? errorMessage)
+        {
+            errorMessage = _canWrite ? null : _error;
+            return _canWrite;
+        }
+    }
+
+    private sealed class StubJarSource : IJarSource
+    {
+        private readonly string _cachePath;
+        private readonly FileInfo? _cachedJar;
+        public StubJarSource(string cachePath, FileInfo? cachedJar)
+        {
+            _cachePath = cachePath;
+            _cachedJar = cachedJar;
+        }
+        public string CachePath => _cachePath;
+        public FileInfo? TryFindCachedJar() => _cachedJar;
+        public Task<FileInfo> EnsureJarAsync(
+            bool forceRefresh = false,
+            IProgress<(long downloaded, long total)>? prog = null,
+            CancellationToken token = default,
+            JarOverrides? overrides = null)
+            => Task.FromResult(_cachedJar ?? throw new InvalidOperationException("No JAR cached"));
+    }
+
+    private sealed class StubGitHubProbe : IGitHubReachabilityProbe
+    {
+        private readonly GitHubReachabilityResult _result;
+        public StubGitHubProbe(GitHubReachabilityResult result) => _result = result;
+        public Task<GitHubReachabilityResult> PingAsync(TimeSpan timeout, CancellationToken cancelToken)
+            => Task.FromResult(_result);
+    }
+
+    private sealed class StubDiskSpaceProbe : IDiskSpaceProbe
+    {
+        private readonly long? _free;
+        public StubDiskSpaceProbe(long? free) => _free = free;
+        public long? GetFreeBytes(string path) => _free;
+    }
+}

--- a/tests/Synthea.Cli.UnitTests/DoctorCommandTests.cs
+++ b/tests/Synthea.Cli.UnitTests/DoctorCommandTests.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Synthea.Cli;
+using Xunit;
+
+namespace Synthea.Cli.UnitTests;
+
+public class DoctorCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly StubJarSource _jarSource;
+    private readonly StubJavaDetector _java = new();
+    private readonly StubFileSystem _fs = new();
+    private readonly StubGitHubProbe _gitHub = new();
+    private readonly StubDiskSpaceProbe _disk = new();
+    private readonly ServiceProvider _services;
+
+    public DoctorCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+        _jarSource = new StubJarSource(_tempDir);
+        _disk.FreeBytes = 50L * 1024 * 1024 * 1024;
+
+        var sc = new ServiceCollection();
+        sc.AddSingleton<IProcessRunner>(new NoopProcessRunner());
+        sc.AddSingleton<IJarSource>(_jarSource);
+        sc.AddSingleton<IJavaDetector>(_java);
+        sc.AddSingleton<IFileSystem>(_fs);
+        sc.AddSingleton<IGitHubReachabilityProbe>(_gitHub);
+        sc.AddSingleton<IDiskSpaceProbe>(_disk);
+        _services = sc.BuildServiceProvider();
+    }
+
+    public void Dispose()
+    {
+        _services.Dispose();
+        try { Directory.Delete(_tempDir, true); } catch { }
+    }
+
+    [Fact]
+    public async Task Doctor_AllOk_ReturnsExitZero()
+    {
+        var code = await Program.RunAsync(new[] { "doctor" }, _services);
+        Assert.Equal(0, code);
+    }
+
+    [Fact]
+    public async Task Doctor_JavaTooOld_ReturnsExitOne()
+    {
+        _java.Result = new JavaProbeResult(true, 11, "11.0.20", null);
+        var code = await Program.RunAsync(new[] { "doctor" }, _services);
+        Assert.Equal(1, code);
+    }
+
+    [Fact]
+    public async Task Doctor_OnlyWarnings_ReturnsExitZero()
+    {
+        _jarSource.CachedJar = null; // → Warn ("no JAR cached")
+        _gitHub.Result = new GitHubReachabilityResult(false, null, 5000, "timed out");
+        var code = await Program.RunAsync(new[] { "doctor" }, _services);
+        Assert.Equal(0, code);
+    }
+
+    [Fact]
+    public async Task Doctor_FailOverridesWarn_ReturnsExitOne()
+    {
+        _jarSource.CachedJar = null; // Warn
+        _disk.FreeBytes = 100L * 1024 * 1024; // Fail
+        var code = await Program.RunAsync(new[] { "doctor" }, _services);
+        Assert.Equal(1, code);
+    }
+
+    [Fact]
+    public async Task Doctor_HonorsRootJavaPathOption()
+    {
+        var code = await Program.RunAsync(new[] { "--java-path", "/opt/jdk21/bin/java", "doctor" }, _services);
+        Assert.Equal(0, code);
+        Assert.Equal("/opt/jdk21/bin/java", _java.LastPath);
+    }
+
+    // Golden-shape check: the table has aligned columns and a summary line.
+    [Fact]
+    public void FormatReport_AllOk_HasAlignedColumnsAndPassedSummary()
+    {
+        var results = new List<DoctorCheckResult>
+        {
+            new("Java", DoctorSeverity.Ok, "Java 21"),
+            new("Cache dir", DoctorSeverity.Ok, "writeable"),
+            new("Cached JAR", DoctorSeverity.Ok, "5d old"),
+            new("Config", DoctorSeverity.Ok, "valid"),
+            new("GitHub", DoctorSeverity.Ok, "200 OK"),
+            new("Disk space", DoctorSeverity.Ok, "42 GB free"),
+        };
+        var report = DoctorCommand.FormatReport(results);
+        Assert.Contains("synthea doctor", report);
+        Assert.Contains("All checks passed.", report);
+        // Every status line starts with one of the three severity tags.
+        var lines = report.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Where(l => l.StartsWith("["))
+            .ToArray();
+        Assert.Equal(6, lines.Length);
+        Assert.All(lines, l => Assert.StartsWith("[ OK ]", l));
+        // Column 2 (the name) starts at the same byte offset on every line.
+        var nameStarts = lines.Select(l => l.IndexOf("J") >= 0 ? l.IndexOf(l.Trim()[6]) : -1).ToArray();
+        var nameColumn = lines.Select(l => l.Substring("[ OK ]".Length).TakeWhile(c => c == ' ').Count()).Distinct();
+        Assert.Single(nameColumn);
+    }
+
+    [Fact]
+    public void FormatReport_FailPresent_SummaryReportsCount()
+    {
+        var results = new List<DoctorCheckResult>
+        {
+            new("Java", DoctorSeverity.Fail, "Java 11"),
+            new("Disk space", DoctorSeverity.Fail, "low"),
+            new("Cache dir", DoctorSeverity.Ok, "ok"),
+        };
+        var report = DoctorCommand.FormatReport(results);
+        Assert.Contains("2 critical issues", report);
+    }
+
+    [Fact]
+    public void FormatReport_WarnOnly_SummaryReportsCount()
+    {
+        var results = new List<DoctorCheckResult>
+        {
+            new("Cached JAR", DoctorSeverity.Warn, "none cached"),
+            new("Java", DoctorSeverity.Ok, "21"),
+        };
+        var report = DoctorCommand.FormatReport(results);
+        Assert.Contains("1 warning", report);
+        Assert.Contains("still run", report);
+    }
+
+    [Fact]
+    public void ExitCodeFor_AllOk_IsZero()
+    {
+        var code = DoctorCommand.ExitCodeFor(new[]
+        {
+            new DoctorCheckResult("a", DoctorSeverity.Ok, ""),
+            new DoctorCheckResult("b", DoctorSeverity.Ok, ""),
+        });
+        Assert.Equal(0, code);
+    }
+
+    [Fact]
+    public void ExitCodeFor_WarnOnly_IsZero()
+    {
+        var code = DoctorCommand.ExitCodeFor(new[]
+        {
+            new DoctorCheckResult("a", DoctorSeverity.Ok, ""),
+            new DoctorCheckResult("b", DoctorSeverity.Warn, ""),
+        });
+        Assert.Equal(0, code);
+    }
+
+    [Fact]
+    public void ExitCodeFor_AnyFail_IsOne()
+    {
+        var code = DoctorCommand.ExitCodeFor(new[]
+        {
+            new DoctorCheckResult("a", DoctorSeverity.Ok, ""),
+            new DoctorCheckResult("b", DoctorSeverity.Warn, ""),
+            new DoctorCheckResult("c", DoctorSeverity.Fail, ""),
+        });
+        Assert.Equal(1, code);
+    }
+
+    // ----- Stubs ----------------------------------------------------------
+
+    private sealed class StubJarSource : IJarSource
+    {
+        public StubJarSource(string cachePath)
+        {
+            CachePath = cachePath;
+            var jarPath = Path.Combine(cachePath, "synthea-with-dependencies.jar");
+            File.WriteAllBytes(jarPath, new byte[1024]);
+            File.SetLastWriteTimeUtc(jarPath, DateTime.UtcNow.AddDays(-3));
+            CachedJar = new FileInfo(jarPath);
+        }
+        public string CachePath { get; }
+        public FileInfo? CachedJar { get; set; }
+        public FileInfo? TryFindCachedJar() => CachedJar;
+        public Task<FileInfo> EnsureJarAsync(
+            bool forceRefresh = false,
+            IProgress<(long downloaded, long total)>? prog = null,
+            CancellationToken token = default,
+            JarOverrides? overrides = null)
+            => Task.FromResult(CachedJar ?? throw new InvalidOperationException("no jar"));
+    }
+
+    private sealed class StubJavaDetector : IJavaDetector
+    {
+        public JavaProbeResult Result { get; set; } = new(true, 21, "21.0.5", null);
+        public string? LastPath { get; private set; }
+        public Task<JavaProbeResult> ProbeAsync(string javaPath, CancellationToken cancelToken = default)
+        {
+            LastPath = javaPath;
+            return Task.FromResult(Result);
+        }
+    }
+
+    private sealed class StubFileSystem : IFileSystem
+    {
+        public bool CanWrite { get; set; } = true;
+        public string? Error { get; set; }
+        public bool TryProbeWrite(string directoryPath, out string? errorMessage)
+        {
+            errorMessage = CanWrite ? null : (Error ?? "denied");
+            return CanWrite;
+        }
+    }
+
+    private sealed class StubGitHubProbe : IGitHubReachabilityProbe
+    {
+        public GitHubReachabilityResult Result { get; set; } = new(true, 200, 198, null);
+        public Task<GitHubReachabilityResult> PingAsync(TimeSpan timeout, CancellationToken cancelToken)
+            => Task.FromResult(Result);
+    }
+
+    private sealed class StubDiskSpaceProbe : IDiskSpaceProbe
+    {
+        public long? FreeBytes { get; set; }
+        public long? GetFreeBytes(string path) => FreeBytes;
+    }
+
+    // Doctor doesn't spawn any processes today, but DI requires the binding.
+    private sealed class NoopProcessRunner : IProcessRunner
+    {
+        public IProcess Start(System.Diagnostics.ProcessStartInfo psi)
+            => throw new InvalidOperationException("doctor should not start processes");
+    }
+}


### PR DESCRIPTION
## Summary

Adds `synthea doctor` (v-next **B6**) — a six-check environment probe that surfaces Java version, cache directory writeability, cached JAR age, config file parseability, GitHub reachability, and free disk space in one table. Exit 1 on any FAIL; OK + WARN exits 0.

- `DoctorCheck.cs` — `DoctorSeverity` enum, `DoctorCheckResult` record, `IDoctorCheck` interface, `IFileSystem` + `DefaultFileSystem` write-probe shim.
- `IGitHubReachabilityProbe.cs` / `IDiskSpaceProbe.cs` — small testable interfaces with HEAD + DriveInfo defaults.
- `DoctorCommand.cs` — six checks (Java / Cache dir / Cached JAR / Config / GitHub / Disk space) composed via DI; aligned-column report; exit policy.
- `Program.cs` — DI registrations for the new probes; doctor-only services use `GetService` + defaults so pre-existing test fixtures keep working.

## Why this shape

- Config check uses `LoadOrThrow` directly so it can *report* malformed JSON as a FAIL row rather than being short-circuited by `RunCommand`'s Phase 2 guard.
- GitHub blip = WARN, not FAIL — `--jar` already gives users a complete bypass of GitHub.
- Per-check classes live inside `DoctorCommand` to stay within the declared file scope while keeping each check independently testable.

## Test plan

- [x] `dotnet build -warnaserror` clean
- [x] `dotnet test --no-build --filter "Category!=Integration"` — 223 passed
- [x] `dotnet format --verify-no-changes --severity warn` clean
- [x] Coverage 89.13% line / 84.15% branch (gate 80/75)
- [x] Local `synthea doctor` smoke test produces aligned report
- [ ] CI green on ubuntu + windows + CodeQL legs

🤖 Generated with [Claude Code](https://claude.com/claude-code)