### PR TITLE
feat(platform): auto OS-correct module separator + subfolders for big runs (C4, C5)

### DIFF
--- a/src/Synthea.Cli/RunCommand.cs
+++ b/src/Synthea.Cli/RunCommand.cs
@@ -296,10 +296,15 @@ internal static class RunCommand
         }
         if (o.Modules is not null)
         {
+            // C4: callers cross-OS habituated to one path separator can pass
+            // the other and we silently translate. Synthea's `-m` is
+            // colon/semicolon joined via java.io.File.pathSeparator (`:`
+            // on Unix, `;` on Windows); a Linux scripter who pipes the
+            // same command to a Windows runner shouldn't break.
             foreach (var m in o.Modules)
             {
                 argList.Add("--module");
-                argList.Add(m);
+                argList.Add(NormalizeModuleSeparators(m));
             }
         }
         if (o.InitialSnapshot is not null)
@@ -379,6 +384,16 @@ internal static class RunCommand
             {
                 argList.Add("--" + kv);
             }
+        }
+        // C5: With more than 10k patients in one directory, filesystem
+        // browsers and shells (mostly Windows Explorer) get slow. Enabling
+        // Synthea's id-substring subfolder bucketing keeps the JSON output
+        // tree usable. We skip this if the caller already set the property
+        // via --property so an explicit override always wins.
+        if (o.Population is int pop && pop > SubfoldersAutoThreshold
+            && !PropertiesContainKey(o.Properties, SubfoldersPropertyKey))
+        {
+            argList.Add($"--{SubfoldersPropertyKey}=true");
         }
         if (!string.IsNullOrWhiteSpace(o.FhirVersion))
         {
@@ -937,6 +952,30 @@ internal static class RunCommand
                                   System.Globalization.DateTimeStyles.None, out _)
             ? null
             : $"Date must be ISO YYYY-MM-DD (got '{v}').";
+
+    // ----- Platform niceties (C4 + C5) -----------------------------------
+
+    internal const string SubfoldersPropertyKey = "exporter.subfolders_by_id_substring";
+    internal const int SubfoldersAutoThreshold = 10_000;
+
+    internal static string NormalizeModuleSeparators(string value)
+    {
+        if (string.IsNullOrEmpty(value)) return value;
+        var foreign = OperatingSystem.IsWindows() ? ':' : ';';
+        var local = Path.PathSeparator;
+        return foreign == local ? value : value.Replace(foreign, local);
+    }
+
+    internal static bool PropertiesContainKey(string[]? properties, string key)
+    {
+        if (properties is null || properties.Length == 0) return false;
+        var prefix = key + "=";
+        foreach (var p in properties)
+        {
+            if (p.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+        return false;
+    }
 
     // C3: --java-heap <size> — overrides the population-based heap tier.
     // The value is the raw -Xmx payload (e.g. "4g", "1024m"); we accept

--- a/tests/Synthea.Cli.UnitTests/ProgramRefactorTests.cs
+++ b/tests/Synthea.Cli.UnitTests/ProgramRefactorTests.cs
@@ -366,6 +366,103 @@ public class ProgramRefactorTests
         Assert.Equal(expected, Program.DetectLogLevel(args));
     }
 
+    // C4: cross-OS separator translation. Local separator stays local;
+    // foreign one is rewritten so Synthea's java.io.File.pathSeparator
+    // tokenizer sees the right delimiter.
+    [Fact]
+    public void Modules_ForeignSeparator_TranslatedToLocal()
+    {
+        var foreign = OperatingSystem.IsWindows() ? ':' : ';';
+        var local = Path.PathSeparator;
+        var input = $"a{foreign}b{foreign}c";
+        var normalized = RunCommand.NormalizeModuleSeparators(input);
+        Assert.Equal($"a{local}b{local}c", normalized);
+    }
+
+    [Fact]
+    public void Modules_LocalSeparator_PassedThroughUnchanged()
+    {
+        var local = Path.PathSeparator;
+        var input = $"a{local}b";
+        Assert.Equal(input, RunCommand.NormalizeModuleSeparators(input));
+    }
+
+    [Fact]
+    public void Modules_NoSeparator_PassedThroughUnchanged()
+    {
+        Assert.Equal("asthma", RunCommand.NormalizeModuleSeparators("asthma"));
+    }
+
+    [Fact]
+    public void BuildArgumentList_ModuleSeparator_Normalized()
+    {
+        var foreign = OperatingSystem.IsWindows() ? ':' : ';';
+        var local = Path.PathSeparator;
+        var args = new SyntheaArgs(
+            State: null, City: null, Gender: null, AgeRange: null,
+            ModuleDir: null, Modules: new[] { $"flu{foreign}covid" },
+            Population: null, Seed: null, Config: null, Zip: null, FhirVersion: null,
+            InitialSnapshot: null, UpdatedSnapshot: null, DaysForward: null,
+            Formats: System.Array.Empty<string>(),
+            AdditionalFormats: System.Array.Empty<string>(),
+            Passthru: System.Array.Empty<string>());
+        var list = RunCommand.BuildArgumentList(args);
+        Assert.Contains($"flu{local}covid", list);
+    }
+
+    // C5: automatic subfolders_by_id_substring above the 10k threshold,
+    // unless the caller has already set the property explicitly.
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData(1, false)]
+    [InlineData(10_000, false)]
+    [InlineData(10_001, true)]
+    [InlineData(50_000, true)]
+    public void BuildArgumentList_SubfoldersAutoEmit_FollowsPopulation(int? population, bool expected)
+    {
+        var args = new SyntheaArgs(
+            State: null, City: null, Gender: null, AgeRange: null,
+            ModuleDir: null, Modules: null, Population: population, Seed: null,
+            Config: null, Zip: null, FhirVersion: null,
+            InitialSnapshot: null, UpdatedSnapshot: null, DaysForward: null,
+            Formats: System.Array.Empty<string>(),
+            AdditionalFormats: System.Array.Empty<string>(),
+            Passthru: System.Array.Empty<string>());
+        var list = RunCommand.BuildArgumentList(args);
+        var emitted = list.Contains($"--{RunCommand.SubfoldersPropertyKey}=true");
+        Assert.Equal(expected, emitted);
+    }
+
+    [Fact]
+    public void BuildArgumentList_SubfoldersUserSet_NoAutoEmit()
+    {
+        // The user set subfolders=false explicitly; auto-emit must back off
+        // so we don't duplicate the property and trigger a stronger value.
+        var args = new SyntheaArgs(
+            State: null, City: null, Gender: null, AgeRange: null,
+            ModuleDir: null, Modules: null, Population: 50_000, Seed: null,
+            Config: null, Zip: null, FhirVersion: null,
+            InitialSnapshot: null, UpdatedSnapshot: null, DaysForward: null,
+            Formats: System.Array.Empty<string>(),
+            AdditionalFormats: System.Array.Empty<string>(),
+            Passthru: System.Array.Empty<string>(),
+            Properties: new[] { $"{RunCommand.SubfoldersPropertyKey}=false" });
+        var list = RunCommand.BuildArgumentList(args);
+        Assert.Contains($"--{RunCommand.SubfoldersPropertyKey}=false", list);
+        Assert.DoesNotContain($"--{RunCommand.SubfoldersPropertyKey}=true", list);
+    }
+
+    [Theory]
+    [InlineData("exporter.subfolders_by_id_substring=true", true)]
+    [InlineData("EXPORTER.subfolders_by_ID_substring=false", true)] // case-insensitive
+    [InlineData("other.property=true", false)]
+    [InlineData("exporter.subfolders_by_id_substring", false)]      // not KEY=VALUE → not set
+    public void PropertiesContainKey_MatchesIgnoringCase(string property, bool expected)
+    {
+        Assert.Equal(expected, RunCommand.PropertiesContainKey(
+            new[] { property }, RunCommand.SubfoldersPropertyKey));
+    }
+
     private sealed class NoopRunner : IProcessRunner
     {
         public IProcess Start(ProcessStartInfo psi) => throw new NotSupportedException();


### PR DESCRIPTION
## Summary

Two paper-cut fixes from v-next **C4** and **C5**:

- **C4** — Translate `:` → `;` (Windows) or `;` → `:` (Unix) inside `--module` values automatically. Synthea's `-m` tokenizer uses `java.io.File.pathSeparator`, so a Linux script copy-pasted into a Windows runner used to error out with an opaque \"module not found\" message.
- **C5** — Auto-emit `--exporter.subfolders_by_id_substring=true` when `--population > 10000` unless the user already set the property via `--property`. Keeps Windows Explorer usable on large output directories without making everyone memorize a long property name.

## Test plan

- [x] `dotnet build -warnaserror` clean
- [x] `dotnet test --no-build --filter \"Category!=Integration\"` — 288 passed (14 new)
- [x] `dotnet format --verify-no-changes --severity warn` clean
- [x] Coverage 89.36% line / 83.28% branch (gate 80/75)
- [ ] CI green on ubuntu + windows + CodeQL legs

🤖 Generated with [Claude Code](https://claude.com/claude-code)