### PR TITLE
feat(help): --version shows JAR, --help has examples, --dry-run alias (D1, D4, D8)

### DIFF
--- a/src/Synthea.Cli/Program.cs
+++ b/src/Synthea.Cli/Program.cs
@@ -1,9 +1,12 @@
 using System;
 using System.CommandLine;
 using System.IO;
+using System.IO.Compression;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -129,8 +132,84 @@ internal static class Program
         root.Subcommands.Add(DoctorCommand.Build(jarSource, javaDetector, fileSystem, gitHubProbe, diskProbe, javaOpt));
         root.Subcommands.Add(ModulesCommand.Build(jarSource));
 
+        // D1: intercept --version before the framework's stock handler so we
+        // can render a two-line report including the cached JAR's version
+        // and date. Only short-circuits the bare `synthea --version` form;
+        // `synthea --version --help` still falls through to --help.
+        if (args.Length > 0 && args[0] == "--version")
+        {
+            Console.WriteLine(BuildVersionReport(jarSource));
+            return 0;
+        }
+
         if (args.Length == 0) args = new[] { "--help" };
         return await root.Parse(args).InvokeAsync();
+    }
+
+    // D1: returns the multi-line version report. Public + ServiceLocator-
+    // free for testability — pass any IJarSource (real or stubbed).
+    internal static string BuildVersionReport(IJarSource jarSource)
+    {
+        var sb = new StringBuilder();
+        sb.Append("synthea-cli ").Append(GetCliVersion()).AppendLine();
+        var cached = SafeFindCachedJar(jarSource);
+        if (cached is null)
+        {
+            sb.Append("synthea-jar (not yet cached — run `synthea run` once to download)");
+        }
+        else
+        {
+            var jarVer = TryReadJarVersion(cached.FullName) ?? "version unavailable";
+            sb.Append("synthea-jar ").Append(jarVer)
+              .Append(" (cached ").Append(cached.LastWriteTimeUtc.ToString("yyyy-MM-dd")).Append(')');
+        }
+        return sb.ToString();
+    }
+
+    private static FileInfo? SafeFindCachedJar(IJarSource jarSource)
+    {
+        try { return jarSource.TryFindCachedJar(); }
+        catch (IOException) { return null; }
+        catch (UnauthorizedAccessException) { return null; }
+    }
+
+    internal static string GetCliVersion()
+    {
+        var asm = typeof(Program).Assembly;
+        var info = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        return info ?? asm.GetName().Version?.ToString() ?? "unknown";
+    }
+
+    // Cheap MANIFEST.MF read. Synthea's JAR puts Implementation-Version in
+    // META-INF/MANIFEST.MF; if not present, fall back to a filename-shape
+    // guess (e.g. synthea-3.3.0-with-dependencies.jar). Returns null if we
+    // can't determine anything.
+    internal static string? TryReadJarVersion(string jarPath)
+    {
+        try
+        {
+            using var archive = ZipFile.OpenRead(jarPath);
+            var manifest = archive.GetEntry("META-INF/MANIFEST.MF");
+            if (manifest is not null)
+            {
+                using var stream = manifest.Open();
+                using var reader = new StreamReader(stream);
+                string? line;
+                while ((line = reader.ReadLine()) is not null)
+                {
+                    if (line.StartsWith("Implementation-Version:", StringComparison.OrdinalIgnoreCase))
+                        return line.Substring("Implementation-Version:".Length).Trim();
+                }
+            }
+        }
+        catch (IOException) { /* fall through */ }
+        catch (InvalidDataException) { /* not a valid zip */ }
+
+        // Filename fallback: synthea-X.Y.Z-with-dependencies.jar
+        var name = Path.GetFileName(jarPath);
+        var match = System.Text.RegularExpressions.Regex.Match(
+            name, @"synthea-(?<v>\d+\.\d+\.\d+)", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        return match.Success ? match.Groups["v"].Value : null;
     }
 
     internal static LogLevel DetectLogLevel(string[] args)

--- a/src/Synthea.Cli/RunCommand.cs
+++ b/src/Synthea.Cli/RunCommand.cs
@@ -22,7 +22,18 @@ internal static class RunCommand
     internal static Command Build(IProcessRunner runner, IJarSource jarSource, IJavaDetector javaDetector,
         Option<bool> refreshOpt, Option<string?> javaOpt, Option<bool> skipJdkCheckOpt)
     {
-        var runCmd = new Command("run", "Generate synthetic health records");
+        // D4: the description doubles as the long-form help text. System.CommandLine
+        // renders this verbatim under the synopsis, so embedding an
+        // "Examples:" block here is the lightest-weight way to put recipes
+        // in front of users at the point of use.
+        var runCmd = new Command("run",
+            "Generate synthetic health records.\n\n" +
+            "Examples:\n" +
+            "  synthea run -o ./out -p 100 --state OH --add-format CSV\n" +
+            "  synthea run -o ./out -p 5 --state Ohio --gender F --age-range 30-40\n" +
+            "  synthea run -o ./out -p 50000 --us-core-version 7 --fhir-version R5\n" +
+            "  synthea run -o ./out -p 1000 --seed 42 --clinician-seed 7 --single-person-seed 9\n" +
+            "  synthea run -o ./out --jar ~/synthea.jar --dry-run");
 
         var outputOpt = new Option<DirectoryInfo>("--output", "-o")
         {
@@ -46,7 +57,10 @@ internal static class RunCommand
         var daysForwardOpt = CreateDaysForwardOption();
         var formatOpt = CreateFormatOption();
         var addFormatOpt = CreateAddFormatOption();
-        var printArgsOpt = new Option<bool>("--print-args")
+        // D8: --dry-run is the canonical user-facing name (the usual CLI
+        // idiom); --print-args stays as an alias so existing scripts and
+        // docs from earlier releases keep working.
+        var printArgsOpt = new Option<bool>("--dry-run", "--print-args")
         {
             Description = "Print the java command line that would be run, then exit without running it. " +
                           "Useful for debugging or scripting. Does not download the JAR."

--- a/tests/Synthea.Cli.UnitTests/ProgramHandlerTests.cs
+++ b/tests/Synthea.Cli.UnitTests/ProgramHandlerTests.cs
@@ -704,6 +704,65 @@ public class ProgramHandlerTests : IDisposable
         Assert.Contains("--exporter.fhir.bulk_data=true", _runner.StartInfo!.ArgumentList);
     }
 
+    // D1: --version shows a two-line report including the JAR cache info.
+    [Fact]
+    public void BuildVersionReport_NoCachedJar_SaysNotYetCached()
+    {
+        var report = Program.BuildVersionReport(new NoJarStub());
+        Assert.Contains("synthea-cli", report);
+        Assert.Contains("not yet cached", report);
+    }
+
+    [Fact]
+    public void BuildVersionReport_WithCachedJar_IncludesCachedDate()
+    {
+        var report = Program.BuildVersionReport(new StubJarSource(_jar));
+        Assert.Contains("synthea-cli", report);
+        Assert.Contains("synthea-jar", report);
+        Assert.Contains("cached ", report);
+    }
+
+    [Fact]
+    public async Task VersionFlag_ShortCircuitsBeforeFrameworkHandler()
+    {
+        var code = await Run("--version");
+        Assert.Equal(0, code);
+        // The run handler should not have been entered.
+        Assert.Null(_runner.StartInfo);
+    }
+
+    // D8: --dry-run is the canonical alias for --print-args.
+    [Fact]
+    public async Task DryRun_Alias_BehavesLikePrintArgs()
+    {
+        var outDir = Path.Combine(_tempDir, "out-dry-run");
+        var code = await Run("run", "--output", outDir, "--state", "OH", "--dry-run");
+        Assert.Equal(0, code);
+        Assert.Null(_runner.StartInfo); // never spawned a process
+    }
+
+    [Fact]
+    public async Task PrintArgs_LegacyAlias_StillWorks()
+    {
+        var outDir = Path.Combine(_tempDir, "out-print-args");
+        var code = await Run("run", "--output", outDir, "--state", "OH", "--print-args");
+        Assert.Equal(0, code);
+        Assert.Null(_runner.StartInfo);
+    }
+
+    // A bare IJarSource that always reports no cached JAR.
+    private sealed class NoJarStub : IJarSource
+    {
+        public string CachePath => Path.GetTempPath();
+        public FileInfo? TryFindCachedJar() => null;
+        public Task<FileInfo> EnsureJarAsync(
+            bool forceRefresh = false,
+            IProgress<(long downloaded, long total)>? prog = null,
+            CancellationToken token = default,
+            JarOverrides? overrides = null)
+            => throw new InvalidOperationException("no jar in this test");
+    }
+
     [Fact]
     public async Task JavaProcess_NonZeroExit_WithRecognizedStderr_StillReturnsJavasExitCode()
     {


### PR DESCRIPTION
## Summary

Three help-surface polish items from v-next:

- **D1** — `synthea --version` now prints two lines: `synthea-cli <ver+sha>` plus `synthea-jar <ver> (cached YYYY-MM-DD)`, or a friendly \"not yet cached\" line. JAR version is read from `META-INF/MANIFEST.MF` with a filename-pattern fallback.
- **D4** — `synthea run --help` now embeds five copy-pasteable example invocations in the command description.
- **D8** — `--dry-run` is the canonical alias for `--print-args`. The legacy spelling still works.

## Test plan

- [x] `dotnet build -warnaserror` clean
- [x] `dotnet test --no-build --filter \"Category!=Integration\"` — 293 passed
- [x] `dotnet format --verify-no-changes --severity warn` clean
- [x] Coverage 90.21% line / 83.28% branch (gate 80/75)
- [x] Local sanity: `--version`, `run --help`, and `run --dry-run` all emit the new output
- [ ] CI green on ubuntu + windows + CodeQL legs

🤖 Generated with [Claude Code](https://claude.com/claude-code)