### PR TITLE
feat(progress): --progress flag with periodic status (D2)

### DIFF
--- a/src/Synthea.Cli/ProcessHelpers.cs
+++ b/src/Synthea.Cli/ProcessHelpers.cs
@@ -52,14 +52,20 @@ internal static class ProcessHelpers
     // so the caller can inspect tail-of-stderr for a remediation match after
     // the process exits non-zero. Buffer is bounded to avoid pinning a
     // long-running Synthea run's full stderr in memory. (C6)
+    //
+    // D2: the optional `onLine` callback fires synchronously for each
+    // line, before the line hits `dest`. Callers use it to feed the
+    // progress parser; keeping it synchronous keeps ordering predictable
+    // without forcing a queue or async fence.
     internal static async Task<IReadOnlyList<string>> RelayAndCapture(
-        StreamReader src, TextWriter dest, int capacity = 50)
+        StreamReader src, TextWriter dest, int capacity = 50, Action<string>? onLine = null)
     {
         if (capacity <= 0) throw new ArgumentOutOfRangeException(nameof(capacity));
         var ring = new List<string>(capacity);
         string? line;
         while ((line = await src.ReadLineAsync()) is not null)
         {
+            onLine?.Invoke(line);
             dest.WriteLine(line);
             if (ring.Count >= capacity) ring.RemoveAt(0);
             ring.Add(line);

--- a/src/Synthea.Cli/RunCommand.cs
+++ b/src/Synthea.Cli/RunCommand.cs
@@ -96,6 +96,11 @@ internal static class RunCommand
             Description = "Emit FHIR resources as bulk-data NDJSON (--exporter.fhir.bulk_data=true)."
         };
         var javaHeapOpt = CreateJavaHeapOption();                 // C3
+        var progressOpt = new Option<bool>("--progress")          // D2
+        {
+            Description = "Print a periodic 'Generated X/Y patients (Z%)…' status line to stderr " +
+                          "while Synthea runs. Off by default; opt in for long runs."
+        };
         var passthru = CreatePassthruArgument();
 
         runCmd.Options.Add(outputOpt);
@@ -130,6 +135,7 @@ internal static class RunCommand
         runCmd.Options.Add(igDirOpt);
         runCmd.Options.Add(bulkDataOpt);
         runCmd.Options.Add(javaHeapOpt);
+        runCmd.Options.Add(progressOpt);
         runCmd.Arguments.Add(passthru);
 
         runCmd.TreatUnmatchedTokensAsErrors = false;
@@ -147,6 +153,9 @@ internal static class RunCommand
             // sees or anything the test fixtures need to know about.
             var heapOverride = parseResult.GetValue(javaHeapOpt);
             var printArgs = parseResult.GetValue(printArgsOpt);
+            // D2: --progress is presentation-only and never reaches Synthea,
+            // so it sits next to heapOverride rather than in SyntheaArgs.
+            var progressEnabled = parseResult.GetValue(progressOpt);
 
             // C7: malformed ~/.synthea-cli/config.json must fail the run with
             // a clean exit 1 (not a stack trace, not exit 3 from the JAR
@@ -227,10 +236,25 @@ internal static class RunCommand
                 {
                     try { proc.Kill(entireProcessTree: true); } catch { /* already exited */ }
                 });
+                // D2: when --progress is on, feed each stderr line to the
+                // parser and let a 5-second timer emit periodic status. The
+                // timer is owned by this scope so it stops as soon as the
+                // pump finishes; no leak if Synthea crashes early.
+                SyntheaProgressParser? parser = progressEnabled ? new SyntheaProgressParser() : null;
+                Action<string>? onErrLine = parser is null ? null : (string line) => parser.TryConsume(line);
+                var totalPatients = args.Population;
+                using var progressTimer = progressEnabled
+                    ? new Timer(_ => EmitProgress(parser!, totalPatients),
+                                state: null, dueTime: TimeSpan.FromSeconds(5),
+                                period: TimeSpan.FromSeconds(5))
+                    : null;
                 var pumpOut = Task.Run(() => ProcessHelpers.Relay(proc.StandardOutput, Console.Out));
-                var pumpErr = Task.Run(() => ProcessHelpers.RelayAndCapture(proc.StandardError, Console.Error));
+                var pumpErr = Task.Run(() => ProcessHelpers.RelayAndCapture(
+                    proc.StandardError, Console.Error, onLine: onErrLine));
 
                 await Task.WhenAll(pumpOut, pumpErr, proc.WaitForExitAsync());
+                progressTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+                if (parser is not null) EmitProgress(parser, totalPatients);
                 var exitCode = proc.ExitCode;
                 if (exitCode != 0)
                 {
@@ -510,6 +534,25 @@ internal static class RunCommand
         }
         Console.WriteLine();
         return 0;
+    }
+
+    // D2: render a single "Generated X[/Y] (Z%) …" line. Stays on stderr
+    // so it doesn't contaminate stdout for callers piping Synthea's
+    // generated artifacts. We render nothing until the parser sees at
+    // least one patient, so an early-failed run doesn't print "0/...".
+    internal static void EmitProgress(SyntheaProgressParser parser, int? totalPatients)
+    {
+        var count = parser.LastCount;
+        if (count <= 0) return;
+        if (totalPatients is int total && total > 0)
+        {
+            var pct = (int)Math.Min(100, Math.Round(100.0 * count / total));
+            Console.Error.WriteLine($"Generated {count}/{total} patients ({pct}%)…");
+        }
+        else
+        {
+            Console.Error.WriteLine($"Generated {count} patients…");
+        }
     }
 
     private static string QuoteForShell(string s)

--- a/src/Synthea.Cli/SyntheaProgressParser.cs
+++ b/src/Synthea.Cli/SyntheaProgressParser.cs
@@ -1,0 +1,40 @@
+using System.Text.RegularExpressions;
+
+namespace Synthea.Cli;
+
+// D2: Synthea reports per-patient generation progress as stderr lines
+// shaped like `N -- Name (age y/o gender) City, State`. We don't try
+// to parse the name/age/location — just the leading integer, which is
+// Synthea's running count of generated patients. The CLI samples the
+// most recent value on a timer and renders a "Generated X/Y (Z%)..."
+// status line so users can see big runs making forward progress
+// without having to grep stderr themselves.
+internal sealed class SyntheaProgressParser
+{
+    // The leading integer is the only signal we need. Synthea pads with
+    // a leading space when the count crosses 10/100/1000, hence \s* on
+    // each side. We anchor with ^ so we don't match the same integer
+    // when it shows up inside an exception message later.
+    private static readonly Regex LineRegex = new(
+        @"^\s*(?<count>\d+)\s+--\s+",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private int _lastCount;
+
+    internal int LastCount => _lastCount;
+
+    // Returns true if the line was a progress line (and updated state),
+    // false otherwise. Lines that look like progress but report a count
+    // lower than what we've already seen are ignored — Synthea threads
+    // can emit out of order, and we only want monotonic forward motion.
+    internal bool TryConsume(string line)
+    {
+        if (string.IsNullOrEmpty(line)) return false;
+        var m = LineRegex.Match(line);
+        if (!m.Success) return false;
+        if (!int.TryParse(m.Groups["count"].Value, out var n)) return false;
+        if (n <= _lastCount) return true;  // recognized but stale; still a progress line
+        _lastCount = n;
+        return true;
+    }
+}

--- a/tests/Synthea.Cli.UnitTests/ProgramHandlerTests.cs
+++ b/tests/Synthea.Cli.UnitTests/ProgramHandlerTests.cs
@@ -775,4 +775,71 @@ public class ProgramHandlerTests : IDisposable
         var code = await Run("run", "--output", outDir, "--state", "OH");
         Assert.Equal(1, code);
     }
+
+    // D2 (Phase 14): --progress flag.
+
+    [Fact]
+    public async Task Progress_Off_NoStatusLineOnStderr()
+    {
+        // Without --progress, no synthetic "Generated …" line is emitted
+        // even when the runner emits progress-shaped stderr.
+        _runner.StderrText = "1 -- Bob (45 y/o M) Cleveland, Ohio\n2 -- Alice (32 y/o F) Akron, Ohio\n";
+        var (stderr, code) = await RunCapturingStderr("run", "--output", Path.Combine(_tempDir, "out-prog-off"), "--state", "OH", "-p", "2");
+        Assert.Equal(0, code);
+        Assert.DoesNotContain("Generated ", stderr);
+    }
+
+    [Fact]
+    public async Task Progress_On_EmitsFinalStatusLineWhenPatientsReported()
+    {
+        // With --progress, the post-pump flush emits at least one status
+        // line summarizing the parser's final count. We don't try to
+        // exercise the 5-second timer (would slow the suite); the final
+        // flush is the deterministic part of the contract.
+        _runner.StderrText = "1 -- Bob (45 y/o M) Cleveland, Ohio\n2 -- Alice (32 y/o F) Akron, Ohio\n";
+        var (stderr, code) = await RunCapturingStderr("run", "--output", Path.Combine(_tempDir, "out-prog-on"), "--state", "OH", "-p", "2", "--progress");
+        Assert.Equal(0, code);
+        Assert.Contains("Generated 2/2 patients (100%)", stderr);
+    }
+
+    [Fact]
+    public async Task Progress_NoPopulation_FallsBackToCountOnly()
+    {
+        // Without -p we can't render "X/Y (Z%)" — just the count.
+        _runner.StderrText = "1 -- Bob (45 y/o M) Cleveland, Ohio\n";
+        var (stderr, code) = await RunCapturingStderr("run", "--output", Path.Combine(_tempDir, "out-prog-nopop"), "--state", "OH", "--progress");
+        Assert.Equal(0, code);
+        Assert.Contains("Generated 1 patients", stderr);
+        Assert.DoesNotContain("/0", stderr);
+    }
+
+    [Fact]
+    public async Task Progress_NoPatientLines_EmitsNothing()
+    {
+        // The flush is a no-op if the parser never saw a progress-shaped
+        // line — e.g. a run that failed before generation started.
+        _runner.StderrText = "Loading modules...\n";
+        var (stderr, code) = await RunCapturingStderr("run", "--output", Path.Combine(_tempDir, "out-prog-empty"), "--state", "OH", "--progress");
+        Assert.Equal(0, code);
+        Assert.DoesNotContain("Generated ", stderr);
+    }
+
+    private async Task<(string Stderr, int ExitCode)> RunCapturingStderr(params string[] args)
+    {
+        // Swap Console.Error so we can read what RunCommand writes. We
+        // restore it in a finally so an exception in the handler doesn't
+        // leave the static binding rerouted for the next test.
+        var sw = new StringWriter();
+        var original = Console.Error;
+        Console.SetError(sw);
+        try
+        {
+            var code = await Run(args);
+            return (sw.ToString(), code);
+        }
+        finally
+        {
+            Console.SetError(original);
+        }
+    }
 }

--- a/tests/Synthea.Cli.UnitTests/SyntheaProgressParserTests.cs
+++ b/tests/Synthea.Cli.UnitTests/SyntheaProgressParserTests.cs
@@ -1,0 +1,69 @@
+using Synthea.Cli;
+using Xunit;
+
+namespace Synthea.Cli.UnitTests;
+
+public class SyntheaProgressParserTests
+{
+    [Fact]
+    public void TryConsume_RecognizesPatientLine_AdvancesCount()
+    {
+        var p = new SyntheaProgressParser();
+        Assert.True(p.TryConsume("1 -- Bob (45 y/o M) Cleveland, Ohio"));
+        Assert.Equal(1, p.LastCount);
+    }
+
+    [Fact]
+    public void TryConsume_AdvancesAcrossMultipleLines()
+    {
+        var p = new SyntheaProgressParser();
+        p.TryConsume("1 -- Bob (45 y/o M) Cleveland, Ohio");
+        p.TryConsume("2 -- Alice (32 y/o F) Akron, Ohio");
+        p.TryConsume("3 -- Carol (67 y/o F) Toledo, Ohio");
+        Assert.Equal(3, p.LastCount);
+    }
+
+    [Fact]
+    public void TryConsume_PaddedInteger_StillMatches()
+    {
+        // Synthea pads the count column once the run is wider than one digit:
+        // " 9 -- ...", " 10 -- ...", "  99 -- ...". Pre-anchor whitespace must
+        // not break recognition.
+        var p = new SyntheaProgressParser();
+        Assert.True(p.TryConsume("  99 -- Dave (50 y/o M) Cincinnati, Ohio"));
+        Assert.Equal(99, p.LastCount);
+    }
+
+    [Fact]
+    public void TryConsume_LowerCountAfterHigher_IsIgnored()
+    {
+        // Threaded generation can emit lines out of order; once we've
+        // seen N we never regress. The line is still classified as
+        // "a progress line", we just don't update state.
+        var p = new SyntheaProgressParser();
+        p.TryConsume("5 -- E (10 y/o F) X, Ohio");
+        Assert.True(p.TryConsume("3 -- F (20 y/o M) Y, Ohio"));
+        Assert.Equal(5, p.LastCount);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("Exception in thread \"main\" java.lang.NullPointerException")]
+    [InlineData("Loading modules...")]
+    [InlineData("[INFO] starting generation")]
+    [InlineData("-- separator --")]
+    public void TryConsume_NonProgressLine_ReturnsFalse(string line)
+    {
+        var p = new SyntheaProgressParser();
+        Assert.False(p.TryConsume(line));
+        Assert.Equal(0, p.LastCount);
+    }
+
+    [Fact]
+    public void TryConsume_NullLine_ReturnsFalse()
+    {
+        var p = new SyntheaProgressParser();
+        Assert.False(p.TryConsume(null!));
+        Assert.Equal(0, p.LastCount);
+    }
+}


### PR DESCRIPTION
## Summary

v0.5 Phase 14 — implements D2 from `SyntheaCli-notes-v-next.md`.

- `SyntheaProgressParser` parses Synthea's per-patient stderr lines (`N -- Name (age y/o gender) City, State`) and tracks the monotonic running count.
- `ProcessHelpers.RelayAndCapture` gets an optional per-line callback so the parser observes lines without disturbing the existing C6 capture-and-relay contract.
- `RunCommand` adds `--progress`, wiring a 5-second timer that prints `Generated X/Y patients (Z%)…` to stderr while Synthea runs, plus a deterministic post-pump flush so the final count is always reported. Off by default.

## Test plan

- [x] `dotnet build` clean (warnings-as-errors)
- [x] `dotnet test --no-build --filter "Category!=Integration"` — 307 passed
- [x] `dotnet format --verify-no-changes --severity warn` clean
- [x] Coverage 90.4% line / 83.77% branch (gate 80/75)
- [x] New code: SyntheaProgressParser 100% line / 87.5% branch
- [x] Scope ⊆ declared phase scope (5 files, all listed in plan)