### PR TITLE
test(api): golden-file --help stability tests (F3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,20 @@ dotnet test tests/Synthea.Cli.UnitTests/Synthea.Cli.UnitTests.csproj `
 
 Coverage gate (enforced in CI): **≥ 80% line, ≥ 75% branch**. Current baseline: 86.96% line / 82.84% branch.
 
+The unit suite includes golden-file `--help` tests that fail the build on accidental CLI-surface drift. When you intentionally change an option name, description, or add a new subcommand, regenerate the goldens in one shot:
+
+```powershell
+$env:SYNTHEA_CLI_REGENERATE_HELP_GOLDENS = "1"
+dotnet test tests/Synthea.Cli.UnitTests --filter HelpSurfaceTests
+Remove-Item env:SYNTHEA_CLI_REGENERATE_HELP_GOLDENS
+```
+
+```bash
+SYNTHEA_CLI_REGENERATE_HELP_GOLDENS=1 dotnet test tests/Synthea.Cli.UnitTests --filter HelpSurfaceTests
+```
+
+The regenerated files land in `tests/Synthea.Cli.UnitTests/golden/`; review the diff and commit them with the feature.
+
 ### Cross-platform CI
 
 GitHub Actions matrix runs on `ubuntu-latest` and `windows-latest` for every PR. CodeQL scans on every push. Dependabot keeps NuGet and GitHub Actions packages current.

--- a/tests/Synthea.Cli.UnitTests/HelpSurfaceTests.cs
+++ b/tests/Synthea.Cli.UnitTests/HelpSurfaceTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Synthea.Cli;
+using Xunit;
+
+namespace Synthea.Cli.UnitTests;
+
+// F3: Golden-file --help tests. The CLI's surface area is part of its
+// contract; option renames, hidden defaults moving into descriptions,
+// or accidentally deleted commands all show up here as a diff before
+// they reach users. Goldens live next to this file in `golden/`.
+//
+// We spawn the actual `Synthea.Cli.dll` via `dotnet exec` for each
+// case rather than calling Program.RunAsync in-process. Reason:
+// Console.SetOut is a process-global; with test parallelism on (A-12)
+// any concurrent test that writes to Console.Out would corrupt the
+// captured help. Subprocess isolation gives a reliable capture with
+// no Program.cs surface change.
+//
+// To intentionally update a golden after a real surface change:
+//   $env:SYNTHEA_CLI_REGENERATE_HELP_GOLDENS = "1"
+//   dotnet test tests/Synthea.Cli.UnitTests --filter HelpSurfaceTests
+// The tests re-write the goldens in the *source* tree (not the test
+// output dir), commit them with the feature, and the suite goes green
+// on the next run.
+public class HelpSurfaceTests
+{
+    private const string RegenerateEnvVar = "SYNTHEA_CLI_REGENERATE_HELP_GOLDENS";
+
+    [Theory]
+    [InlineData("help-root.txt", new[] { "--help" })]
+    [InlineData("help-run.txt", new[] { "run", "--help" })]
+    [InlineData("help-cache.txt", new[] { "cache", "--help" })]
+    [InlineData("help-doctor.txt", new[] { "doctor", "--help" })]
+    [InlineData("help-modules.txt", new[] { "modules", "--help" })]
+    public async Task Help_MatchesGoldenFile(string goldenName, string[] args)
+    {
+        var actual = await CaptureHelpAsync(args);
+        var goldenPath = ResolveGoldenSourcePath(goldenName);
+
+        if (string.Equals(Environment.GetEnvironmentVariable(RegenerateEnvVar), "1", StringComparison.Ordinal))
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(goldenPath)!);
+            File.WriteAllText(goldenPath, actual);
+            return;
+        }
+
+        Assert.True(File.Exists(goldenPath),
+            $"Golden file '{goldenPath}' not found. Generate with: " +
+            $"{RegenerateEnvVar}=1 dotnet test --filter HelpSurfaceTests");
+
+        var expected = Normalize(File.ReadAllText(goldenPath));
+        var normalizedActual = Normalize(actual);
+        if (!string.Equals(expected, normalizedActual, StringComparison.Ordinal))
+        {
+            // Surfacing both texts in the failure message would dwarf
+            // the rest of the test output; point the developer to the
+            // regeneration command instead and show the first diverging
+            // line so a glance tells them what changed.
+            Assert.Fail(
+                $"Help surface drift for '{goldenName}'. " +
+                $"If the change is intentional, regenerate with: " +
+                $"{RegenerateEnvVar}=1 dotnet test --filter HelpSurfaceTests" +
+                Environment.NewLine +
+                FirstDifference(expected, normalizedActual));
+        }
+    }
+
+    private static async Task<string> CaptureHelpAsync(string[] args)
+    {
+        var dllPath = Path.Combine(AppContext.BaseDirectory, "Synthea.Cli.dll");
+        Assert.True(File.Exists(dllPath),
+            $"Synthea.Cli.dll not found at '{dllPath}'. Run `dotnet build` first.");
+
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            // CLI emits UTF-8 (Program.Main sets Console.OutputEncoding).
+            // On Windows the default pipe-read encoding is the ANSI code
+            // page, which mojibakes non-ASCII (e.g. "…" → "ΓÇª"). Force
+            // UTF-8 so what we read matches what the binary wrote.
+            StandardOutputEncoding = System.Text.Encoding.UTF8,
+            StandardErrorEncoding = System.Text.Encoding.UTF8,
+            // Pin a wide terminal so System.CommandLine's help renderer
+            // doesn't soft-wrap based on whatever happens to be the CI
+            // runner's COLUMNS at the moment.
+            EnvironmentVariables = { ["COLUMNS"] = "200" }
+        };
+        psi.ArgumentList.Add("exec");
+        psi.ArgumentList.Add(dllPath);
+        foreach (var a in args) psi.ArgumentList.Add(a);
+
+        using var proc = Process.Start(psi)!;
+        var stdout = await proc.StandardOutput.ReadToEndAsync();
+        await proc.WaitForExitAsync();
+        // --help conventionally exits 0; if a non-zero shows up here we
+        // want the assertion failure to surface the diagnostic.
+        Assert.Equal(0, proc.ExitCode);
+        return stdout;
+    }
+
+    private static string Normalize(string text)
+    {
+        // Goldens are checked in with LF endings but Git on Windows
+        // converts them to CRLF on checkout. Normalize both sides to
+        // LF so the comparison is EOL-independent.
+        return text.Replace("\r\n", "\n").Replace("\r", "\n");
+    }
+
+    private static string FirstDifference(string expected, string actual)
+    {
+        var expLines = expected.Split('\n');
+        var actLines = actual.Split('\n');
+        var max = Math.Max(expLines.Length, actLines.Length);
+        for (var i = 0; i < max; i++)
+        {
+            var e = i < expLines.Length ? expLines[i] : "<missing>";
+            var a = i < actLines.Length ? actLines[i] : "<missing>";
+            if (!string.Equals(e, a, StringComparison.Ordinal))
+            {
+                return $"First diff at line {i + 1}:" + Environment.NewLine +
+                       $"  expected: {e}" + Environment.NewLine +
+                       $"  actual:   {a}";
+            }
+        }
+        return "Outputs differ only in trailing content.";
+    }
+
+    private static string ResolveGoldenSourcePath(string fileName)
+    {
+        // Walk up from the test binary location to the repo root, then
+        // descend to the source-tree copy of the golden. We deliberately
+        // target the *source* path so regeneration produces a file the
+        // developer can commit; the build-output copy is rebuilt next
+        // time `dotnet build` runs.
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Synthea.Cli.sln")))
+            dir = dir.Parent;
+        if (dir is null)
+            throw new InvalidOperationException("Could not locate repo root from " + AppContext.BaseDirectory);
+        return Path.Combine(dir.FullName, "tests", "Synthea.Cli.UnitTests", "golden", fileName);
+    }
+}

--- a/tests/Synthea.Cli.UnitTests/golden/help-cache.txt
+++ b/tests/Synthea.Cli.UnitTests/golden/help-cache.txt
@@ -1,0 +1,18 @@
+Description:
+  Manage the local Synthea JAR cache
+
+Usage:
+  Synthea.Cli cache [command] [options]
+
+Options:
+  -?, -h, --help           Show help and usage information
+  --refresh                Ignore cached JAR and download the newest release
+  --java-path <java-path>  Full path to the Java executable (defaults to 'java' on PATH)
+  --verbose                Enable debug-level logging
+  --quiet                  Suppress info logs; show only warnings and errors
+  --skip-jdk-check         Bypass the Java 17+ preflight check. Use only for custom JREs whose -version output we can't parse; otherwise fix Java first.
+
+Commands:
+  list   List cached Synthea JARs with size and last-modified date
+  clear  Delete all cached Synthea JARs
+

--- a/tests/Synthea.Cli.UnitTests/golden/help-doctor.txt
+++ b/tests/Synthea.Cli.UnitTests/golden/help-doctor.txt
@@ -1,0 +1,14 @@
+Description:
+  Run environment checks and report Java, cache, config, network, and disk status
+
+Usage:
+  Synthea.Cli doctor [options]
+
+Options:
+  -?, -h, --help           Show help and usage information
+  --refresh                Ignore cached JAR and download the newest release
+  --java-path <java-path>  Full path to the Java executable (defaults to 'java' on PATH)
+  --verbose                Enable debug-level logging
+  --quiet                  Suppress info logs; show only warnings and errors
+  --skip-jdk-check         Bypass the Java 17+ preflight check. Use only for custom JREs whose -version output we can't parse; otherwise fix Java first.
+

--- a/tests/Synthea.Cli.UnitTests/golden/help-modules.txt
+++ b/tests/Synthea.Cli.UnitTests/golden/help-modules.txt
@@ -1,0 +1,18 @@
+Description:
+  Inspect Synthea modules bundled in the cached JAR or a --module-dir
+
+Usage:
+  Synthea.Cli modules [command] [options]
+
+Options:
+  -?, -h, --help           Show help and usage information
+  --refresh                Ignore cached JAR and download the newest release
+  --java-path <java-path>  Full path to the Java executable (defaults to 'java' on PATH)
+  --verbose                Enable debug-level logging
+  --quiet                  Suppress info logs; show only warnings and errors
+  --skip-jdk-check         Bypass the Java 17+ preflight check. Use only for custom JREs whose -version output we can't parse; otherwise fix Java first.
+
+Commands:
+  list             List all modules in the cached Synthea JAR and an optional --module-dir
+  describe <name>  Show a module's remarks, GMF version, and state count
+

--- a/tests/Synthea.Cli.UnitTests/golden/help-root.txt
+++ b/tests/Synthea.Cli.UnitTests/golden/help-root.txt
@@ -1,0 +1,28 @@
+Description:
+  CLI wrapper around MITRE Synthea synthetic patient generator
+
+Usage:
+  Synthea.Cli [command] [options]
+
+Options:
+  --refresh                Ignore cached JAR and download the newest release
+  --java-path <java-path>  Full path to the Java executable (defaults to 'java' on PATH)
+  --verbose                Enable debug-level logging
+  --quiet                  Suppress info logs; show only warnings and errors
+  --skip-jdk-check         Bypass the Java 17+ preflight check. Use only for custom JREs whose -version output we can't parse; otherwise fix Java first.
+  -?, -h, --help           Show help and usage information
+  --version                Show version information
+
+Commands:
+  run <args>  Generate synthetic health records.
+  
+              Examples:
+                synthea run -o ./out -p 100 --state OH --add-format CSV
+                synthea run -o ./out -p 5 --state Ohio --gender F --age-range 30-40
+                synthea run -o ./out -p 50000 --us-core-version 7 --fhir-version R5
+                synthea run -o ./out -p 1000 --seed 42 --clinician-seed 7 --single-person-seed 9
+                synthea run -o ./out --jar ~/synthea.jar --dry-run
+  cache       Manage the local Synthea JAR cache
+  doctor      Run environment checks and report Java, cache, config, network, and disk status
+  modules     Inspect Synthea modules bundled in the cached JAR or a --module-dir
+

--- a/tests/Synthea.Cli.UnitTests/golden/help-run.txt
+++ b/tests/Synthea.Cli.UnitTests/golden/help-run.txt
@@ -1,0 +1,60 @@
+Description:
+  Generate synthetic health records.
+  
+  Examples:
+    synthea run -o ./out -p 100 --state OH --add-format CSV
+    synthea run -o ./out -p 5 --state Ohio --gender F --age-range 30-40
+    synthea run -o ./out -p 50000 --us-core-version 7 --fhir-version R5
+    synthea run -o ./out -p 1000 --seed 42 --clinician-seed 7 --single-person-seed 9
+    synthea run -o ./out --jar ~/synthea.jar --dry-run
+
+Usage:
+  Synthea.Cli run [<args>...] [options] [[--] <additional arguments>...]]
+
+Arguments:
+  <args>  Any other arguments forwarded unchanged to synthea.jar
+
+Options:
+  -o, --output <output> (REQUIRED)           Directory where Synthea will write its output
+  --state <state>                            State name (e.g. 'Ohio') or two-letter USPS code (e.g. 'OH'). 2-letter codes are converted to the full name automatically. Rejects unknown names with a suggestion.
+  --city <city>                              City name (optional second positional arg after state)
+  --gender <gender>                          Patient gender filter (M or F)
+  --age-range <age-range>                    Age range filter as min-max
+  --module-dir <module-dir>                  Directory of custom modules
+  --module <module>                          Specific disease modules
+  -p, --population <population>              Number of patients to generate
+  -s, --seed <seed>                          Random seed for deterministic output
+  -c, --config <config>                      Path to Synthea configuration file
+  --zip <zip>                                ZIP code (requires --state)
+  --fhir-version <fhir-version>              FHIR version (STU3, R4, or R5)
+  --initial-snapshot <initial-snapshot>      Path to initial snapshot to load (-i)
+  --updated-snapshot <updated-snapshot>      Path where updated snapshot will be written (-u)
+  --days-forward <days-forward>              Advance time from snapshot by N days (-t)
+  --format <format>                          Output formats to generate (FHIR, CSV, CCDA, BULKFHIR, CPCDS). Exclusive: enables only the named formats and disables all others. Use --add-format to extend Synthea defaults instead.
+  --add-format <add-format>                  Additive format to enable in addition to Synthea defaults (FHIR, CSV, CCDA, BULKFHIR, CPCDS). Repeatable. Does not disable any other format; see --format for exclusive semantics.
+  --dry-run, --print-args                    Print the java command line that would be run, then exit without running it. Useful for debugging or scripting. Does not download the JAR.
+  --jar <jar>                                Path to a Synthea JAR to use directly. Skips the GitHub download. Falls back to SYNTHEA_CLI_JAR_PATH env var, then ~/.synthea-cli/config.json.
+  --insist-checksum                          Fail the run if the upstream release does not publish a .sha256 asset.
+  --reference-date <reference-date>          Reference date (ISO YYYY-MM-DD). Maps to Synthea -r YYYYMMDD.
+  --end-date <end-date>                      Simulation end date (ISO YYYY-MM-DD). Maps to Synthea -e YYYYMMDD. Requires --allow-future-end if the date is beyond today.
+  --allow-future-end                         Permit --end-date beyond today (Synthea -E).
+  --clinician-seed <clinician-seed>          Random seed for clinician generation (Synthea -cs N).
+  --single-person-seed <single-person-seed>  Random seed for single-person generation (Synthea -ps N).
+  --overflow                                 Allow Synthea's overflow generation (-o true). Off by default; turn on for full-fidelity reruns of past results.
+  --property <property>                      Set a Synthea property as KEY=VALUE (repeatable). Emitted as --KEY=VALUE. Use for properties without a first-class flag.
+  --us-core-version <us-core-version>        US Core IG version to apply to FHIR export. Allowed: 3.1.1, 4, 5, 6, 7. Implies --exporter.fhir.use_us_core_ig=true.
+  --flexporter-mapping <flexporter-mapping>  Path to a Flexporter mapping file (.yaml/.json). Maps to Synthea -fm <path>.
+  --ig-dir <ig-dir>                          Directory of FHIR Implementation Guide resources. Maps to Synthea -ig <dir>.
+  --bulk-data                                Emit FHIR resources as bulk-data NDJSON (--exporter.fhir.bulk_data=true).
+  --java-heap <java-heap>                    Override the auto-sized JVM heap (e.g. '4g' or '1024m'). Defaults: 2g for >=1k, 4g for >=10k, 8g for >=100k, 16g for >=1M; no flag for <1k (use JVM default).
+  --progress                                 Print a periodic 'Generated X/Y patients (Z%)…' status line to stderr while Synthea runs. Off by default; opt in for long runs.
+  -?, -h, --help                             Show help and usage information
+  --refresh                                  Ignore cached JAR and download the newest release
+  --java-path <java-path>                    Full path to the Java executable (defaults to 'java' on PATH)
+  --verbose                                  Enable debug-level logging
+  --quiet                                    Suppress info logs; show only warnings and errors
+  --skip-jdk-check                           Bypass the Java 17+ preflight check. Use only for custom JREs whose -version output we can't parse; otherwise fix Java first.
+
+Additional Arguments:
+  Arguments passed to the application that is being run.
+


### PR DESCRIPTION
## Summary

v0.5 Phase 15 — implements F3 from `SyntheaCli-notes-v-next.md`.

- Adds `HelpSurfaceTests` which spawns `Synthea.Cli.dll` via `dotnet exec` and diff-compares `--help` output against checked-in goldens for `root`, `run`, `cache`, `doctor`, `modules`.
- Goldens live under `tests/Synthea.Cli.UnitTests/golden/`. Drift fails the build.
- Subprocess capture (not in-process `Console.SetOut`) keeps the test robust against parallel-test corruption of the process-global `Console.Out`.
- `StandardOutputEncoding=UTF8` and a pinned `COLUMNS=200` keep output deterministic across ubuntu + windows matrix legs.
- README documents the `SYNTHEA_CLI_REGENERATE_HELP_GOLDENS=1` workflow for intentional surface changes.

## Test plan

- [x] `dotnet build` clean (warnings-as-errors)
- [x] `dotnet test --no-build --filter "Category!=Integration"` — 312 passed (+5 from baseline)
- [x] `dotnet format --verify-no-changes --severity warn` clean
- [x] Coverage 90.4% line / 83.77% branch (gate 80/75)
- [x] Scope ⊆ declared phase scope (HelpSurfaceTests.cs + 5 goldens + README)