### PR TITLE
ci(release): auto-extract release notes from conventional commits (F4)

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,46 @@
+name: Release Notes
+
+# Fires after the maintainer pushes a vX.Y.Z tag. The matching GitHub
+# Release is created automatically (or pre-existing — `gh release create
+# --notes ""` is idempotent here), and this workflow rewrites the body
+# with a grouped Conventional Commits summary so the release page is
+# useful out of the box.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need full history to walk back to the previous tag.
+          fetch-depth: 0
+
+      - name: Generate release notes
+        id: notes
+        shell: pwsh
+        run: |
+          $notes = & pwsh -File tools/extract-release-notes.ps1 -ToRef ${{ github.ref_name }}
+          # Use a delimiter so multiline output survives the env transport.
+          $delim = "EOF_$([guid]::NewGuid().ToString('N'))"
+          "notes<<$delim"      | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          $notes               | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          $delim               | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          if gh release view "$tag" > /dev/null 2>&1; then
+            gh release edit "$tag" --notes "${{ steps.notes.outputs.notes }}"
+          else
+            gh release create "$tag" --title "$tag" --notes "${{ steps.notes.outputs.notes }}"
+          fi

--- a/README.md
+++ b/README.md
@@ -296,11 +296,20 @@ GitHub Actions matrix runs on `ubuntu-latest` and `windows-latest` for every PR.
 
 ### Releasing
 
-Tag a version (`vX.Y.Z`) and push. `.github/workflows/nuget.yml` runs `dotnet pack` and `dotnet nuget push` automatically.
+Tag a version (`vX.Y.Z`) and push. Two workflows fire on the tag:
+
+- `.github/workflows/nuget.yml` runs `dotnet pack` and `dotnet nuget push`.
+- `.github/workflows/release-notes.yml` runs `tools/extract-release-notes.ps1` against the commit range since the previous tag, groups commits by Conventional Commits type (`feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`, `ci`, `chore`), and writes the grouped markdown to the GitHub Release body.
 
 ```bash
 git tag -a v0.4.1 -m "..."
 git push origin v0.4.1
+```
+
+To preview the notes locally before tagging:
+
+```powershell
+pwsh -File tools/extract-release-notes.ps1 v0.4.0 HEAD
 ```
 
 ### Useful project structure

--- a/tools/extract-release-notes.ps1
+++ b/tools/extract-release-notes.ps1
@@ -1,0 +1,123 @@
+# Extract grouped Conventional-Commits release notes between two refs.
+#
+# Usage:
+#   pwsh -File tools/extract-release-notes.ps1 v0.4.0 v0.5.0
+#   pwsh -File tools/extract-release-notes.ps1 v0.4.0 HEAD
+#   pwsh -File tools/extract-release-notes.ps1                 # auto: previous tag .. HEAD
+#
+# Output: markdown to stdout. The release-notes.yml workflow pipes this
+# straight into `gh release edit --notes-file -`.
+
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [string]$FromRef,
+
+    [Parameter(Position = 1)]
+    [string]$ToRef = 'HEAD'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ([string]::IsNullOrWhiteSpace($FromRef)) {
+    # Most recent tag reachable from ToRef minus one — i.e. the previous
+    # release. `git describe --tags --abbrev=0 ToRef^` excludes ToRef
+    # itself when it is the newly pushed tag.
+    $FromRef = (& git describe --tags --abbrev=0 "$ToRef^" 2>$null)
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($FromRef)) {
+        Write-Error "Could not determine a previous tag from $ToRef. Pass FromRef explicitly."
+    }
+}
+
+$range = "$FromRef..$ToRef"
+
+# Each commit on its own line: "<short-sha>\t<subject>". We don't pull
+# body or trailers — release notes derive from subjects only, which is
+# the Conventional Commits contract.
+$log = & git log --no-merges --pretty=format:'%h%x09%s' $range
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "git log $range failed."
+}
+if ([string]::IsNullOrWhiteSpace($log)) {
+    # Empty range — still emit a useful header so downstream `gh release
+    # edit` doesn't fail with empty input.
+    "## Changes since $FromRef"
+    ""
+    "_No commits between $FromRef and $ToRef._"
+    return
+}
+
+# Conventional Commits headers we care about. Order = display order in
+# the output; anything not matching a known prefix lands under "Other".
+$buckets = [ordered]@{
+    'feat'     = 'Features'
+    'fix'      = 'Fixes'
+    'perf'     = 'Performance'
+    'refactor' = 'Refactors'
+    'docs'     = 'Documentation'
+    'test'     = 'Tests'
+    'build'    = 'Build'
+    'ci'       = 'CI'
+    'chore'    = 'Chores'
+}
+
+# Map bucket key -> List<string> of formatted entries.
+$grouped = [ordered]@{}
+foreach ($key in $buckets.Keys) { $grouped[$key] = [System.Collections.Generic.List[string]]::new() }
+$other = [System.Collections.Generic.List[string]]::new()
+
+# `feat(scope): subject` -> capture type, scope (optional), subject.
+$pattern = '^(?<type>[a-z]+)(?<bang>!)?(?:\((?<scope>[^)]+)\))?:\s*(?<rest>.+)$'
+
+foreach ($line in ($log -split "`n")) {
+    if ([string]::IsNullOrWhiteSpace($line)) { continue }
+    $parts = $line -split "`t", 2
+    if ($parts.Length -lt 2) { continue }
+    $sha = $parts[0].Trim()
+    $subject = $parts[1].Trim()
+
+    $m = [regex]::Match($subject, $pattern)
+    if (-not $m.Success) {
+        $other.Add("- $subject ($sha)")
+        continue
+    }
+    $type = $m.Groups['type'].Value.ToLowerInvariant()
+    $scope = $m.Groups['scope'].Value
+    $rest = $m.Groups['rest'].Value
+    $breaking = $m.Groups['bang'].Success
+    $scopePart = if ($scope) { "**$scope**: " } else { '' }
+    $breakingPart = if ($breaking) { ' ⚠ **BREAKING**' } else { '' }
+    $entry = "- $scopePart$rest$breakingPart ($sha)"
+
+    if ($grouped.Contains($type)) {
+        $grouped[$type].Add($entry)
+    }
+    else {
+        $other.Add($entry)
+    }
+}
+
+# Render markdown — header per non-empty bucket, then "Other" if any.
+$sb = [System.Text.StringBuilder]::new()
+[void]$sb.AppendLine("## Changes since $FromRef")
+[void]$sb.AppendLine()
+$emitted = $false
+foreach ($key in $buckets.Keys) {
+    $entries = $grouped[$key]
+    if ($entries.Count -eq 0) { continue }
+    [void]$sb.AppendLine("### $($buckets[$key])")
+    foreach ($e in $entries) { [void]$sb.AppendLine($e) }
+    [void]$sb.AppendLine()
+    $emitted = $true
+}
+if ($other.Count -gt 0) {
+    [void]$sb.AppendLine('### Other')
+    foreach ($e in $other) { [void]$sb.AppendLine($e) }
+    [void]$sb.AppendLine()
+    $emitted = $true
+}
+if (-not $emitted) {
+    [void]$sb.AppendLine("_No matching commits between $FromRef and $ToRef._")
+}
+
+Write-Output $sb.ToString().TrimEnd()


### PR DESCRIPTION
## Summary

v0.5 Phase 17 — implements F4 from `SyntheaCli-notes-v-next.md`.

- `tools/extract-release-notes.ps1` walks `git log <prev-tag>..<ref>`, parses Conventional Commits, and emits grouped markdown (Features / Fixes / Performance / Refactors / Docs / Tests / Build / CI / Chores / Other). Breaking changes marked `!` are flagged inline.
- `.github/workflows/release-notes.yml` runs the script on tag push, then `gh release edit --notes` (or `gh release create`) so the release body matches.
- README releasing section documents the workflow + local preview command.

Verified locally with `pwsh -File tools/extract-release-notes.ps1 v0.4.0 HEAD` — produced 14 Features / 1 Docs / 1 Tests / 1 Chores grouped under "Changes since v0.4.0". End-to-end verification deferred to the v0.5.0 tag push at the Final phase (the workflow only fires on tag push).

## Test plan

- [x] `dotnet build` clean (warnings-as-errors)
- [x] `dotnet test --no-build --filter "Category!=Integration"` — 312 passed
- [x] `dotnet format --verify-no-changes --severity warn` clean
- [x] Local script preview produces the expected grouped markdown
- [x] Scope ⊆ declared phase scope (workflow + script + README)